### PR TITLE
feat(cotizador): nuevo flujo Edificio + opciones de reserva Casa

### DIFF
--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -151,6 +151,7 @@ interface WizardState {
   webpayData: { order: string; token: string; url: string; buy_order: string } | null
   customerSaving: boolean
   customerSaved: boolean
+  selectedReserveOption: 'r70' | 'r30' | 'visita' | null
   showEdificioData: boolean
   edificioFloor: string
   edificioParkingFloor: string
@@ -390,6 +391,7 @@ export default function CotizadorWizard() {
     webpayData: null,
     customerSaving: false,
     customerSaved: false,
+    selectedReserveOption: null,
     showEdificioData: false,
     edificioFloor: '',
     edificioParkingFloor: '',
@@ -505,6 +507,63 @@ export default function CotizadorWizard() {
   function goBack() {
     if (state.step > 0) {
       update({ step: state.step - 1, activePanel: null })
+    }
+  }
+
+  // Calls /api/payment and immediately submits form to Webpay (no intermediate panel)
+  async function payDirect(amount: number, glosa: string) {
+    update({ webpayLoading: true, webpayError: '' })
+    const displayResult = state.apiResult ?? result
+    const vat = Math.round(amount * 0.19 / 1.19)
+    try {
+      const res = await fetch('/api/payment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          total: amount,
+          vat,
+          email: state.emailPago || undefined,
+          address: state.address || undefined,
+          tipo: state.tipo,
+          chargerName: displayResult?.chargerName ?? '',
+          dist: state.dist,
+          glosa,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.token) throw new Error(data.error ?? 'Error al iniciar el pago')
+
+      sessionStorage.setItem('paymentData', JSON.stringify({
+        tipo: state.tipo ?? '',
+        chargerName: displayResult?.chargerName ?? '',
+        dist: state.dist,
+        address: state.address,
+        depto: state.depto ?? '',
+        email: state.emailPago ?? '',
+        total: amount,
+        neto: amount - vat,
+        iva: vat,
+        chargerPrice: displayResult?.chargerPrice ?? 0,
+        mat: displayResult?.mat ?? 0,
+        inst: displayResult?.inst ?? 0,
+        sec: displayResult?.sec ?? 0,
+        isOwn: displayResult?.isOwn ?? false,
+      }))
+      sessionStorage.removeItem('wizardContext')
+
+      const form = document.createElement('form')
+      form.method = 'POST'
+      form.action = data.url
+      const tokenInput = document.createElement('input')
+      tokenInput.type = 'hidden'
+      tokenInput.name = 'token_ws'
+      tokenInput.value = data.token
+      form.appendChild(tokenInput)
+      document.body.appendChild(form)
+      form.submit()
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Error al procesar el pago'
+      update({ webpayLoading: false, webpayError: message })
     }
   }
 
@@ -795,6 +854,7 @@ export default function CotizadorWizard() {
       webpayData: null,
       customerSaving: false,
       customerSaved: false,
+      selectedReserveOption: null,
       showEdificioData: false,
       edificioFloor: '',
       edificioParkingFloor: '',
@@ -1295,16 +1355,12 @@ export default function CotizadorWizard() {
             <Button
               fullWidth
               variant="contained"
-              onClick={() => {
-                if (state.activePanel === 'pago') {
-                  update({ activePanel: null, webpayData: null, webpayError: '', webpayLoading: false })
-                } else {
-                  initiatePayment()
-                }
-              }}
+              disabled={state.webpayLoading}
+              onClick={() => payDirect(29000, 'Visita técnica · Electrolinera en edificio')}
               sx={{
-                bgcolor: state.activePanel === 'pago' ? '#94A3B8' : PINK,
-                '&:hover': { bgcolor: state.activePanel === 'pago' ? '#64748B' : PINK_DARK },
+                bgcolor: PINK,
+                '&:hover': { bgcolor: PINK_DARK },
+                '&:disabled': { bgcolor: '#e0e0e0', color: '#aaa' },
                 fontWeight: 700,
                 py: 1.25,
                 fontSize: '0.9rem',
@@ -1312,7 +1368,7 @@ export default function CotizadorWizard() {
                 borderRadius: 2,
               }}
             >
-              Pagar visita y recibir mi kit →
+              {state.webpayLoading ? 'Redirigiendo…' : 'Pagar visita y recibir mi kit →'}
             </Button>
           </Box>
         </Box>
@@ -1544,6 +1600,190 @@ export default function CotizadorWizard() {
     return `${cap(weekday)}, ${day} ${cap(month)}`
   }
 
+  // ─── Casa booking options (Image #7) ─────────────────────────────────────────
+  function renderBookingOptions(displayResult: NonNullable<ReturnType<typeof calcResult>>) {
+    const installBase = displayResult.neto - displayResult.chargerPrice
+
+    const inst70 = Math.round(installBase * 0.85)
+    const save70 = installBase - inst70
+    const pay70 = Math.round(inst70 * 0.70)
+    const bal70 = inst70 - pay70
+
+    const inst30 = Math.round(installBase * 0.93)
+    const save30 = installBase - inst30
+    const pay30 = Math.round(inst30 * 0.30)
+    const bal30 = inst30 - pay30
+
+    const visitaAmount = 10000
+
+    const opts = [
+      {
+        key: 'r70' as const,
+        title: 'Reserva 70%',
+        badge: { label: 'MEJOR PRECIO', color: '#00C47C' },
+        instDisc: inst70,
+        instOrig: installBase,
+        savings: save70,
+        savingsPct: 15,
+        payToday: pay70,
+        balance: bal70,
+        chargerDeferred: displayResult.chargerPrice,
+        features: ['Prioridad máxima en la agenda de instalación', 'Visita técnica sin costo', 'Puedes desistir tras la visita y te devolvemos lo pagado'],
+        disclaimer: 'Si en la visita técnica detectamos algún impedimento técnico para instalar, te devolvemos el 100% de lo pagado, sin preguntas.',
+        btnLabel: `Reservar con ${fmt(pay70)} →`,
+        payAmount: pay70,
+        glosa: 'Reserva 70% · Instalación cargador eléctrico',
+        highlight: false,
+      },
+      {
+        key: 'r30' as const,
+        title: 'Reserva 30%',
+        badge: { label: '🔥 LA MÁS ELEGIDA', color: PINK },
+        instDisc: inst30,
+        instOrig: installBase,
+        savings: save30,
+        savingsPct: 7,
+        payToday: pay30,
+        balance: bal30,
+        chargerDeferred: displayResult.chargerPrice,
+        features: ['Prioridad en la instalación', 'Visita técnica sin costo', 'Puedes desistir tras la visita y te devolvemos lo pagado'],
+        disclaimer: null,
+        btnLabel: `Reservar con ${fmt(pay30)} →`,
+        payAmount: pay30,
+        glosa: 'Reserva 30% · Instalación cargador eléctrico',
+        highlight: true,
+      },
+    ]
+
+    return (
+      <Box sx={{ mb: 2 }}>
+        <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 2 }}>
+          Elige cómo reservar tu instalación
+        </Typography>
+
+        {state.webpayError && (
+          <Alert severity="error" sx={{ mb: 2, fontSize: '0.8rem' }}>{state.webpayError}</Alert>
+        )}
+
+        {opts.map(opt => (
+          <Box
+            key={opt.key}
+            sx={{
+              bgcolor: '#fff',
+              border: `2px solid ${opt.highlight ? PINK : BORDER}`,
+              borderRadius: 2,
+              overflow: 'hidden',
+              mb: 2,
+            }}
+          >
+            {opt.badge && (
+              <Box sx={{ bgcolor: opt.badge.color, px: 2, py: 0.75, display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: '0.72rem', color: '#fff', letterSpacing: '0.06em' }}>
+                  {opt.badge.label}
+                </Typography>
+              </Box>
+            )}
+            <Box sx={{ p: { xs: 2, sm: 2.5 } }}>
+              <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 0.75 }}>{opt.title}</Typography>
+
+              <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 0.25 }}>
+                <Typography sx={{ fontWeight: 800, fontSize: '1.25rem', color: '#2A3547' }}>{fmt(opt.instDisc)}</Typography>
+                <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, textDecoration: 'line-through' }}>{fmt(opt.instOrig)}</Typography>
+              </Box>
+              <Typography sx={{ fontSize: '0.8rem', color: SUCCESS, fontWeight: 600, mb: 1.5 }}>
+                {opt.savingsPct}% dcto · ahorras {fmt(opt.savings)} en la instalación
+              </Typography>
+
+              <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 0.5, lineHeight: 1.6 }}>
+                Pagas hoy <strong>{fmt(opt.payToday)}</strong> ({opt.key === 'r70' ? '70' : '30'}% de la instalación). Saldo <strong>{fmt(opt.balance)}</strong> tras la visita técnica.
+              </Typography>
+              {!displayResult.isOwn && (
+                <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 1.5, lineHeight: 1.6 }}>
+                  Cargador {fmt(opt.chargerDeferred)}, se paga después de la visita técnica.
+                </Typography>
+              )}
+
+              {opt.features.map(f => (
+                <Box key={f} sx={{ display: 'flex', gap: 1, mb: 0.5, alignItems: 'flex-start' }}>
+                  <Typography sx={{ color: SUCCESS, fontWeight: 700, flexShrink: 0, fontSize: '0.9rem' }}>✓</Typography>
+                  <Typography sx={{ fontSize: '0.82rem', color: '#2A3547', fontWeight: 600 }}>{f}</Typography>
+                </Box>
+              ))}
+              {opt.disclaimer && (
+                <Typography sx={{ fontSize: '0.73rem', color: TEXT_MUTED, mt: 1, lineHeight: 1.5, fontStyle: 'italic' }}>
+                  {opt.disclaimer}
+                </Typography>
+              )}
+
+              <Button
+                fullWidth
+                variant="contained"
+                disabled={state.webpayLoading}
+                onClick={() => payDirect(opt.payAmount, opt.glosa)}
+                sx={{
+                  bgcolor: PINK,
+                  '&:hover': { bgcolor: PINK_DARK },
+                  '&:disabled': { bgcolor: '#e0e0e0', color: '#aaa' },
+                  fontWeight: 700,
+                  py: 1.25,
+                  fontSize: '0.9rem',
+                  boxShadow: 'none',
+                  borderRadius: 2,
+                  mt: 2,
+                }}
+              >
+                {state.webpayLoading ? 'Redirigiendo…' : opt.btnLabel}
+              </Button>
+            </Box>
+          </Box>
+        ))}
+
+        {/* Solo visita técnica */}
+        <Box sx={{ bgcolor: '#fff', border: `1px solid ${BORDER}`, borderRadius: 2, p: { xs: 2, sm: 2.5 }, mb: 2 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 0.5 }}>
+            Solo visita técnica
+          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 0.5 }}>
+            <Typography sx={{ fontWeight: 800, fontSize: '1.35rem', color: '#2A3547' }}>{fmt(visitaAmount)}</Typography>
+            <Typography sx={{ fontSize: '0.82rem', color: TEAL, fontWeight: 600 }}>acreditable a tu instalación</Typography>
+          </Box>
+          <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 1.5, lineHeight: 1.6 }}>
+            Agenda la visita, recibe tu presupuesto definitivo y decide después. Sin compromiso de instalar.
+          </Typography>
+          {[
+            'Profesional certificado SEC en terreno',
+            'Presupuesto definitivo y plan de instalación',
+            'Si avanzas, los $10.000 se descuentan',
+          ].map(f => (
+            <Box key={f} sx={{ display: 'flex', gap: 1, mb: 0.5, alignItems: 'flex-start' }}>
+              <Typography sx={{ color: SUCCESS, fontWeight: 700, flexShrink: 0, fontSize: '0.9rem' }}>✓</Typography>
+              <Typography sx={{ fontSize: '0.82rem', color: '#2A3547' }}>{f}</Typography>
+            </Box>
+          ))}
+          <Button
+            fullWidth
+            variant="outlined"
+            disabled={state.webpayLoading}
+            onClick={() => payDirect(visitaAmount, 'Visita técnica · Instalación cargador')}
+            sx={{
+              borderColor: BORDER,
+              color: '#2A3547',
+              '&:hover': { borderColor: '#2A3547', bgcolor: 'rgba(0,0,0,0.02)' },
+              '&:disabled': { borderColor: '#e0e0e0', color: '#aaa' },
+              fontWeight: 700,
+              py: 1.25,
+              fontSize: '0.9rem',
+              mt: 2,
+              borderRadius: 2,
+            }}
+          >
+            {state.webpayLoading ? 'Redirigiendo…' : `Pagar visita ${fmt(visitaAmount)} →`}
+          </Button>
+        </Box>
+      </Box>
+    )
+  }
+
   function renderStep2() {
     if (state.tipo === 'edificio') return renderStep2Edificio()
 
@@ -1748,33 +1988,10 @@ export default function CotizadorWizard() {
           </Typography>
         </Box>
 
-        {/* Pay button — red when panel hidden, gray when panel visible (acts as toggle) */}
-        <Box sx={{ mb: 2 }}>
-          <Button
-            fullWidth
-            variant="contained"
-            onClick={() => {
-              if (state.activePanel === 'pago') {
-                update({ activePanel: null, webpayData: null, webpayError: '', webpayLoading: false })
-              } else {
-                initiatePayment()
-              }
-            }}
-            sx={{
-              bgcolor: state.activePanel === 'pago' ? '#94A3B8' : 'rgb(240, 56, 107)',
-              color: '#ffffff',
-              '&:hover': { bgcolor: state.activePanel === 'pago' ? '#64748B' : 'rgb(239, 97, 136)' },
-              fontWeight: 700,
-              fontSize: '0.85rem',
-              py: 1.25,
-              boxShadow: 'none',
-            }}
-          >
-            Reservar instalación
-          </Button>
-        </Box>
+        {/* Booking options — replaces single "Reservar" button */}
+        {renderBookingOptions(displayResult)}
 
-        {/* Panel: pago */}
+        {/* Panel: pago — kept for legacy/fallback */}
         {state.activePanel === 'pago' && (
           <Box sx={{ bgcolor: SURFACE, border: `1px solid ${BORDER}`, borderRadius: 2, p: 2.5, mb: 2 }}>
             <Typography sx={{ fontWeight: 700, fontSize: '0.95rem', mb: 2, color: '#2A3547' }}>

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -37,6 +37,11 @@ const SUCCESS = '#00C47C'
 // ─── Constants ───────────────────────────────────────────────────────────────
 const GMAPS_KEY = 'AIzaSyBdAjJeBoZ8ehrL0byX2ZBHHtQSI6pfIvQ'
 
+const PARKING_FLOORS = [
+  'Piso 1', 'Piso 2', 'Piso 3',
+  'Subterráneo -1', 'Subterráneo -2', 'Subterráneo -3', 'Subterráneo -4',
+]
+
 // ─── Data ────────────────────────────────────────────────────────────────────
 const CHARGERS = [
   { id: 'workersbee', name: 'Workersbee 2.2–7 kW', tipo: 'portable', kw: '2.2–7', desc: 'Portable · Potencia regulable · Cable de carga', precio: 299000, stock: 2 },
@@ -146,6 +151,11 @@ interface WizardState {
   webpayData: { order: string; token: string; url: string; buy_order: string } | null
   customerSaving: boolean
   customerSaved: boolean
+  showEdificioData: boolean
+  edificioFloor: string
+  edificioParkingFloor: string
+  edificioVisitorParking: boolean | null
+  edificioOption: 'dedicated' | 'shared' | null
 }
 
 interface CalcResult {
@@ -380,6 +390,11 @@ export default function CotizadorWizard() {
     webpayData: null,
     customerSaving: false,
     customerSaved: false,
+    showEdificioData: false,
+    edificioFloor: '',
+    edificioParkingFloor: '',
+    edificioVisitorParking: null,
+    edificioOption: null,
   })
 
   // Initialize dates client-only to avoid SSR/hydration mismatch (Math.random + Date)
@@ -391,8 +406,8 @@ export default function CotizadorWizard() {
   // ─── Derived ─────────────────────────────────────────────────────────────
   const canNext = (() => {
     if (state.step === 0) return state.tipo !== null
-    // 'own' is pre-selected by default so just need tipoC chosen
-    if (state.step === 1) return state.tipoC !== null
+    if (state.step === 1 && !state.showEdificioData) return state.tipoC !== null
+    if (state.showEdificioData) return state.edificioFloor.trim() !== '' && state.edificioParkingFloor !== ''
     return true
   })()
 
@@ -400,12 +415,16 @@ export default function CotizadorWizard() {
     ? '¡Visita agendada!'
     : state.paid
     ? STEP_TITLES[state.step] ?? '¡Todo confirmado!'
+    : state.showEdificioData
+    ? 'Tu edificio'
     : STEP_TITLES[state.step] ?? 'Cotiza tu instalación'
 
   const heroSubtitle = state.booked
     ? 'Te contactaremos para confirmar los detalles'
     : state.paid
     ? STEP_SUBTITLES[state.step] ?? ''
+    : state.showEdificioData
+    ? 'Datos de tu edificio para calcular el costo de instalación'
     : STEP_SUBTITLES[state.step] ?? ''
 
   // ─── Handlers ────────────────────────────────────────────────────────────
@@ -414,15 +433,22 @@ export default function CotizadorWizard() {
   }
 
   async function goNext() {
-    if (state.step === 1) {
-      update({ estimateLoading: true })
+    // Edificio: intercept step 1 → show edificio data form first
+    if (state.step === 1 && state.tipo === 'edificio' && !state.showEdificioData) {
+      update({ showEdificioData: true })
+      return
+    }
+
+    // Trigger cotizar: from step 1 (casa) OR after completing edificio data form
+    const shouldCotizar = (state.step === 1 && state.tipo === 'casa') || state.showEdificioData
+    if (shouldCotizar) {
+      update({ showEdificioData: false, estimateLoading: true })
       try {
         const isWallbox = state.tipoC === 'wallbox'
         const isPortable = state.tipoC === 'portable'
         const isHouse = state.tipo === 'casa'
         const charger = state.chargerId !== 'own' ? CHARGERS.find(c => c.id === state.chargerId) : null
 
-        // Call Next.js API route — server-side AppSync call avoids client auth issues
         const res = await fetch('/api/cotizar', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -445,7 +471,6 @@ export default function CotizadorWizard() {
           if (est) {
             const chargerPrice = charger ? Math.round(charger.precio / 1.19) : 0
             const chargerName = state.chargerId === 'own' ? 'Ya tiene cargador' : (charger?.name ?? '')
-            // Force SEC trámite from local base (API may return 0) so it always appears in the breakdown
             const secTramite = isHouse ? INSTALL_BASE.casa.sec : INSTALL_BASE.edificio.sec
             const installNeto = Number(est.netPrice ?? 0)
             const totalNeto = installNeto + chargerPrice + secTramite
@@ -471,21 +496,25 @@ export default function CotizadorWizard() {
           }
         } else {
           const err = await res.json().catch(() => ({}))
-          console.error('[cotizador2] /api/cotizar error:', err)
+          console.error('[cotizador] /api/cotizar error:', err)
         }
       } catch (err) {
-        console.error('[cotizador2] fetch /api/cotizar failed, falling back to local calc:', err)
+        console.error('[cotizador] fetch /api/cotizar failed, falling back to local calc:', err)
       }
-      // Fallback: show local calculation
       update({ estimateLoading: false, step: 2 })
       return
     }
+
     if (state.step < 2) {
       update({ step: state.step + 1 })
     }
   }
 
   function goBack() {
+    if (state.showEdificioData) {
+      update({ showEdificioData: false })
+      return
+    }
     if (state.step > 0) {
       update({ step: state.step - 1, activePanel: null })
     }
@@ -778,6 +807,11 @@ export default function CotizadorWizard() {
       webpayData: null,
       customerSaving: false,
       customerSaved: false,
+      showEdificioData: false,
+      edificioFloor: '',
+      edificioParkingFloor: '',
+      edificioVisitorParking: null,
+      edificioOption: null,
     })
   }
 
@@ -958,6 +992,318 @@ export default function CotizadorWizard() {
     )
   }
 
+  // ─── Step: edificio data collection ──────────────────────────────────────────
+  function renderEdificioData() {
+    return (
+      <Box>
+        <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5, color: '#2A3547' }}>
+          Cuéntanos de tu edificio
+        </Typography>
+        <Typography sx={{ fontSize: '0.85rem', color: TEXT_MUTED, mb: 3, lineHeight: 1.6 }}>
+          En edificios el costo depende del recorrido del cable desde el tablero común hasta tu estacionamiento.
+        </Typography>
+
+        <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 1, color: '#2A3547' }}>
+          ¿En qué piso vives?
+        </Typography>
+        <TextField
+          fullWidth
+          size="small"
+          type="number"
+          placeholder="5"
+          inputProps={{ min: -10, max: 60 }}
+          value={state.edificioFloor}
+          onChange={e => update({ edificioFloor: e.target.value })}
+          sx={{
+            mb: 3,
+            '& .MuiOutlinedInput-root': {
+              bgcolor: '#fff',
+              '& fieldset': { borderColor: BORDER },
+              '&:hover fieldset': { borderColor: TEAL },
+              '&.Mui-focused fieldset': { borderColor: TEAL },
+            },
+          }}
+        />
+
+        <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 1, color: '#2A3547' }}>
+          ¿En qué piso está tu estacionamiento?
+        </Typography>
+        <FormControl fullWidth size="small" sx={{ mb: 3 }}>
+          <Select
+            displayEmpty
+            value={state.edificioParkingFloor}
+            onChange={(e: SelectChangeEvent<string>) => update({ edificioParkingFloor: e.target.value as string })}
+            renderValue={(val: string) =>
+              val
+                ? val
+                : <Typography sx={{ color: TEXT_MUTED, fontSize: '0.875rem' }}>Selecciona un piso…</Typography>
+            }
+            sx={{
+              bgcolor: '#fff',
+              '& .MuiOutlinedInput-notchedOutline': { borderColor: BORDER },
+              '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: TEAL },
+              '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: TEAL },
+              fontSize: '0.875rem',
+            }}
+          >
+            <MenuItem value="" disabled>
+              <Typography sx={{ color: TEXT_MUTED, fontSize: '0.875rem' }}>Selecciona un piso…</Typography>
+            </MenuItem>
+            {PARKING_FLOORS.map(f => (
+              <MenuItem key={f} value={f} sx={{ fontSize: '0.875rem' }}>{f}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 0.5, color: '#2A3547' }}>
+          ¿Tu edificio tiene estacionamiento de visitas?
+        </Typography>
+        <Typography sx={{ fontSize: '0.78rem', color: TEXT_MUTED, mb: 1.5 }}>
+          Es donde podríamos instalar la electrolinera compartida.
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid size={{ xs: 6 }}>
+            <Box
+              onClick={() => update({ edificioVisitorParking: true })}
+              role="button"
+              tabIndex={0}
+              onKeyDown={e => e.key === 'Enter' && update({ edificioVisitorParking: true })}
+              sx={{
+                border: `2px solid ${state.edificioVisitorParking === true ? PINK : BORDER}`,
+                borderRadius: 2,
+                p: 2,
+                cursor: 'pointer',
+                bgcolor: state.edificioVisitorParking === true ? 'rgba(232,26,104,0.04)' : '#fff',
+                textAlign: 'center',
+                transition: 'all 0.2s',
+                '&:hover': { borderColor: PINK, bgcolor: 'rgba(232,26,104,0.04)' },
+              }}
+            >
+              <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: state.edificioVisitorParking === true ? PINK : '#2A3547' }}>
+                Sí
+              </Typography>
+            </Box>
+          </Grid>
+          <Grid size={{ xs: 6 }}>
+            <Box
+              onClick={() => update({ edificioVisitorParking: false })}
+              role="button"
+              tabIndex={0}
+              onKeyDown={e => e.key === 'Enter' && update({ edificioVisitorParking: false })}
+              sx={{
+                border: `2px solid ${state.edificioVisitorParking === false ? PINK : BORDER}`,
+                borderRadius: 2,
+                p: 2,
+                cursor: 'pointer',
+                bgcolor: state.edificioVisitorParking === false ? 'rgba(232,26,104,0.04)' : '#fff',
+                textAlign: 'center',
+                transition: 'all 0.2s',
+                '&:hover': { borderColor: PINK, bgcolor: 'rgba(232,26,104,0.04)' },
+              }}
+            >
+              <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: state.edificioVisitorParking === false ? PINK : '#2A3547' }}>
+                No
+              </Typography>
+            </Box>
+          </Grid>
+        </Grid>
+      </Box>
+    )
+  }
+
+  // ─── Step 2: edificio option selector ────────────────────────────────────────
+  function renderStep2Edificio() {
+    const localResult = result
+    const displayResult = state.apiResult ?? localResult
+    if (!displayResult) return null
+
+    const rangeLow = Math.round(displayResult.total * 0.82)
+    const rangeHigh = Math.round(displayResult.total * 1.38)
+
+    return (
+      <Box>
+        <Box sx={{ textAlign: 'center', mb: 2 }}>
+          <Typography sx={{ fontSize: '0.95rem', fontWeight: 700, color: '#2A3547' }}>
+            Tu estimación referencial
+          </Typography>
+          <Typography sx={{ fontSize: '0.8rem', color: TEXT_MUTED, mt: 0.25 }}>
+            Edificio · recorrido estimado {state.dist} m
+          </Typography>
+        </Box>
+
+        {/* Community notice */}
+        <Box sx={{ bgcolor: SURFACE, border: `1px solid ${BORDER}`, borderRadius: 1.5, p: 2, mb: 3 }}>
+          <Box sx={{ display: 'flex', gap: 1, mb: 0.75, alignItems: 'flex-start' }}>
+            <Typography sx={{ fontSize: '1rem', flexShrink: 0 }}>🏢</Typography>
+            <Typography sx={{ fontSize: '0.85rem', fontWeight: 700, color: '#2A3547', lineHeight: 1.4 }}>
+              En un edificio no decides solo: necesitas el OK de la comunidad
+            </Typography>
+          </Box>
+          <Typography sx={{ fontSize: '0.8rem', color: TEXT_MUTED, lineHeight: 1.6, pl: '1.75rem' }}>
+            Por eso no te cobramos una instalación que aún no está aprobada. Te damos las herramientas para conseguir ese permiso — y la opción que casi siempre lo logra más rápido.
+          </Typography>
+        </Box>
+
+        {/* Price range */}
+        <Box sx={{ textAlign: 'center', mb: 3 }}>
+          <Typography sx={{ fontSize: '0.72rem', color: TEXT_MUTED, mb: 0.5, letterSpacing: '0.03em' }}>
+            Rango referencial de instalación dedicada
+          </Typography>
+          <Typography sx={{ fontSize: { xs: '1.5rem', sm: '1.75rem' }, fontWeight: 900, color: '#2A3547', lineHeight: 1.1 }}>
+            {fmt(rangeLow)} – {fmt(rangeHigh)}
+          </Typography>
+          <Typography sx={{ fontSize: '0.75rem', color: TEXT_MUTED, mt: 0.5 }}>
+            El precio definitivo se confirma con visita técnica.
+          </Typography>
+        </Box>
+
+        {/* Option 1: Instalación dedicada */}
+        <Box sx={{ bgcolor: '#fff', border: `1px solid ${BORDER}`, borderRadius: 2, p: { xs: 2, sm: 2.5 }, mb: 2 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 0.75 }}>
+            Instalación dedicada en tu estacionamiento
+          </Typography>
+          <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 2, lineHeight: 1.6 }}>
+            Recibe tu presupuesto definitivo <strong>+ el kit para conseguir la aprobación</strong> de tu comunidad.
+          </Typography>
+
+          <Typography sx={{ fontWeight: 600, fontSize: '0.82rem', mb: 1.25, color: '#2A3547' }}>
+            Después de pagar la visita recibes:
+          </Typography>
+          {[
+            'Visita técnica con profesional certificado SEC',
+            'Presupuesto definitivo en 48 horas',
+            'Carta tipo para presentar a la administración',
+            'Memoria técnica firmada',
+            'Fotos del recorrido propuesto',
+          ].map(item => (
+            <Box key={item} sx={{ display: 'flex', gap: 1, mb: 0.75, alignItems: 'flex-start' }}>
+              <Typography sx={{ color: SUCCESS, fontWeight: 700, flexShrink: 0, fontSize: '0.9rem' }}>✓</Typography>
+              <Typography sx={{ fontSize: '0.82rem', color: '#2A3547', lineHeight: 1.5 }}>{item}</Typography>
+            </Box>
+          ))}
+
+          <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${BORDER}` }}>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 1.5 }}>
+              <Typography sx={{ fontWeight: 900, fontSize: '1.5rem', color: '#2A3547' }}>$29.000</Typography>
+              <Typography sx={{ fontSize: '0.78rem', color: TEXT_MUTED }}>acreditable al presupuesto final</Typography>
+            </Box>
+            <Button
+              fullWidth
+              variant="contained"
+              onClick={() => update({ edificioOption: 'dedicated' })}
+              sx={{
+                bgcolor: PINK,
+                '&:hover': { bgcolor: PINK_DARK },
+                fontWeight: 700,
+                py: 1.25,
+                fontSize: '0.9rem',
+                boxShadow: 'none',
+                borderRadius: 2,
+              }}
+            >
+              Pagar visita y recibir mi kit →
+            </Button>
+          </Box>
+        </Box>
+
+        {/* Option 2: Electrolinera compartida */}
+        <Box sx={{ bgcolor: '#fff', border: `1px solid ${BORDER}`, borderRadius: 2, overflow: 'hidden', mb: 3 }}>
+          <Box sx={{ bgcolor: PINK, px: 2, py: 0.875, display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.8rem' }}>🔥</Typography>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.72rem', color: '#fff', letterSpacing: '0.08em' }}>
+              LA MÁS ELEGIDA
+            </Typography>
+          </Box>
+          <Box sx={{ p: { xs: 2, sm: 2.5 } }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 0.5 }}>
+              Electrolinera compartida · sin costo para ti
+            </Typography>
+            <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 2, lineHeight: 1.6 }}>
+              Energica instala y financia un cargador en el estacionamiento de visitas. Pagas solo lo que cargas.
+            </Typography>
+
+            <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 2.5, mb: 2 }}>
+              <Box>
+                <Typography sx={{ fontWeight: 900, fontSize: '2rem', color: '#2A3547', lineHeight: 1 }}>$0</Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: TEXT_MUTED }}>inversión</Typography>
+              </Box>
+              <Box>
+                <Typography sx={{ fontWeight: 700, fontSize: '1.1rem', color: '#2A3547', lineHeight: 1 }}>$330/kWh</Typography>
+                <Typography sx={{ fontSize: '0.7rem', color: TEXT_MUTED }}>solo lo que cargas</Typography>
+              </Box>
+            </Box>
+
+            {[
+              'Sin obra en tu estacionamiento privado',
+              'No requiere asamblea sobre tu estacionamiento, solo permiso de uso común',
+              'La opción más fácil y rápida de aprobar',
+            ].map(item => (
+              <Box key={item} sx={{ display: 'flex', gap: 1, mb: 0.75, alignItems: 'flex-start' }}>
+                <Typography sx={{ color: SUCCESS, fontWeight: 700, flexShrink: 0, fontSize: '0.9rem' }}>✓</Typography>
+                <Typography sx={{ fontSize: '0.82rem', color: '#2A3547', lineHeight: 1.5 }}>{item}</Typography>
+              </Box>
+            ))}
+
+            <Typography sx={{ fontWeight: 600, fontSize: '0.82rem', mt: 2, mb: 1.25, color: '#2A3547' }}>
+              Te entregamos para tu comité:
+            </Typography>
+            {[
+              'Presentación lista para llevar a la reunión',
+              'Carta de solicitud de autorización',
+              'Visita comercial a la administración (si la pides)',
+            ].map(item => (
+              <Box key={item} sx={{ display: 'flex', gap: 1, mb: 0.75, alignItems: 'flex-start' }}>
+                <Typography sx={{ color: SUCCESS, fontWeight: 700, flexShrink: 0, fontSize: '0.9rem' }}>✓</Typography>
+                <Typography sx={{ fontSize: '0.82rem', color: '#2A3547', lineHeight: 1.5 }}>{item}</Typography>
+              </Box>
+            ))}
+
+            <Box sx={{ mt: 2.5 }}>
+              <Button
+                fullWidth
+                variant="contained"
+                onClick={() => {
+                  sessionStorage.setItem('edificioPostulacion', JSON.stringify({
+                    address: state.address,
+                    dist: state.dist,
+                    formId: state.formId,
+                    floor: state.edificioFloor,
+                    parking: state.edificioParkingFloor,
+                  }))
+                  window.location.href = '/postulacion-cargadores-edificios'
+                }}
+                sx={{
+                  bgcolor: PINK,
+                  '&:hover': { bgcolor: PINK_DARK },
+                  fontWeight: 700,
+                  py: 1.25,
+                  fontSize: '0.9rem',
+                  boxShadow: 'none',
+                  borderRadius: 2,
+                }}
+              >
+                Quiero electrolinera en mi edificio →
+              </Button>
+              <Typography sx={{ fontSize: '0.72rem', color: TEXT_MUTED, textAlign: 'center', mt: 1 }}>
+                Sin compromiso si la comunidad la rechaza.
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+
+        <Box sx={{ textAlign: 'center' }}>
+          <Button
+            variant="text"
+            onClick={resetAll}
+            sx={{ color: TEXT_MUTED, fontSize: '0.82rem', textTransform: 'none', textDecoration: 'underline', '&:hover': { color: '#2A3547', bgcolor: 'transparent' } }}
+          >
+            ← Nueva simulación
+          </Button>
+        </Box>
+      </Box>
+    )
+  }
+
   function formatVisitDate(iso: string): string {
     const d = new Date(iso)
     const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
@@ -968,11 +1314,15 @@ export default function CotizadorWizard() {
   }
 
   function renderStep2() {
+    // Flujo B: edificio shows option selector unless dedicated was chosen
+    if (state.tipo === 'edificio' && state.edificioOption !== 'dedicated') {
+      return renderStep2Edificio()
+    }
+
     const localResult = result
     const displayResult = state.apiResult ?? localResult
     if (!displayResult) return null
 
-    // Summary params for the header (Image #14)
     const tipoLabel = state.tipo === 'casa' ? 'Casa' : 'Edificio'
     const chargerLabel = displayResult.chargerName || 'Cargador propio'
     const distLabel2 = `${state.dist}m`
@@ -1763,8 +2113,9 @@ export default function CotizadorWizard() {
               p: { xs: 3, md: 4 },
             }}
           >
-            {state.step === 0 && renderStep0()}
-            {state.step === 1 && renderStep1()}
+            {state.step === 0 && !state.showEdificioData && renderStep0()}
+            {state.step === 1 && !state.showEdificioData && renderStep1()}
+            {state.showEdificioData && renderEdificioData()}
             {state.step === 2 && renderStep2()}
             {state.step === 3 && renderStep3()}
             {state.step === 4 && renderStep4()}

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -1222,8 +1222,8 @@ export default function CotizadorWizard() {
     const displayResult = state.apiResult ?? localResult
     if (!displayResult) return null
 
-    const rangeLow = Math.round(displayResult.total * 0.82)
-    const rangeHigh = Math.round(displayResult.total * 1.38)
+    const RANGE_LOW = 2350000
+    const RANGE_HIGH = 4110000
 
     return (
       <Box>
@@ -1255,7 +1255,7 @@ export default function CotizadorWizard() {
             Rango referencial de instalación dedicada
           </Typography>
           <Typography sx={{ fontSize: { xs: '1.5rem', sm: '1.75rem' }, fontWeight: 900, color: '#2A3547', lineHeight: 1.1 }}>
-            {fmt(rangeLow)} – {fmt(rangeHigh)}
+            {fmt(RANGE_LOW)} – {fmt(RANGE_HIGH)}
           </Typography>
           <Typography sx={{ fontSize: '0.75rem', color: TEXT_MUTED, mt: 0.5 }}>
             El precio definitivo se confirma con visita técnica.
@@ -1295,10 +1295,16 @@ export default function CotizadorWizard() {
             <Button
               fullWidth
               variant="contained"
-              onClick={() => update({ edificioOption: 'dedicated' })}
+              onClick={() => {
+                if (state.activePanel === 'pago') {
+                  update({ activePanel: null, webpayData: null, webpayError: '', webpayLoading: false })
+                } else {
+                  initiatePayment()
+                }
+              }}
               sx={{
-                bgcolor: PINK,
-                '&:hover': { bgcolor: PINK_DARK },
+                bgcolor: state.activePanel === 'pago' ? '#94A3B8' : PINK,
+                '&:hover': { bgcolor: state.activePanel === 'pago' ? '#64748B' : PINK_DARK },
                 fontWeight: 700,
                 py: 1.25,
                 fontSize: '0.9rem',
@@ -1396,6 +1402,126 @@ export default function CotizadorWizard() {
           </Box>
         </Box>
 
+        {/* Panel de pago — se muestra al hacer clic en "Pagar visita" */}
+        {state.activePanel === 'pago' && (
+          <Box sx={{ bgcolor: SURFACE, border: `1px solid ${BORDER}`, borderRadius: 2, p: 2.5, mb: 2 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.95rem', mb: 2, color: '#2A3547' }}>
+              Datos para la visita técnica
+            </Typography>
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 1, color: '#2A3547' }}>
+              Dirección del edificio
+            </Typography>
+            <Box sx={{ mb: state.address && !state.addressValidated ? 0.5 : 1.5 }}>
+              <AddressInput2
+                value={state.address}
+                error={!!state.address && !state.addressValidated}
+                onAddressChange={(v) => update({ address: v, addressValidated: false, regionWarn: false })}
+                onValidationChange={(isValid) => update({ addressValidated: isValid })}
+                onSelectAddress={(details) => {
+                  if (details) {
+                    const full = [details.StreetAddress, details.City, details.State].filter(Boolean).join(', ')
+                    update({
+                      address: full,
+                      addressValidated: true,
+                      addressCity: details.City ?? '',
+                      addressState: details.State ?? '',
+                      addressZipCode: details.ZipCode ?? '',
+                      addressLat: String(details.Latitude ?? ''),
+                      addressLng: String(details.Longitude ?? ''),
+                      regionWarn: false,
+                    })
+                  }
+                }}
+              />
+            </Box>
+            {state.address && !state.addressValidated && (
+              <Typography sx={{ fontSize: '0.75rem', color: 'error.main', mb: 1.5, ml: 0.25 }}>
+                Selecciona una dirección del menú desplegable para continuar
+              </Typography>
+            )}
+            {state.regionWarn && (
+              <Alert severity="warning" sx={{ fontSize: '0.78rem', mb: 1.5 }}>
+                Por el momento solo atendemos la Región Metropolitana y Valparaíso.
+              </Alert>
+            )}
+            {state.address && !isRegionMetropolitana(state.address) ? (
+              <Box sx={{ p: 2, borderRadius: 2, bgcolor: '#FEF3C7', border: '1px solid #FCD34D', mb: 2 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: '0.85rem', color: '#92400E', mb: 0.75 }}>
+                  Sin cobertura en tu región
+                </Typography>
+                <Typography sx={{ fontSize: '0.82rem', color: '#78350F', lineHeight: 1.6, mb: 1.5 }}>
+                  De momento no tenemos cobertura en tu región por esta vía. Contáctanos para evaluar tu caso.
+                </Typography>
+                <Button size="small" variant="outlined" onClick={() => update({ address: '' })}
+                  sx={{ fontSize: '0.78rem', borderColor: '#92400E', color: '#92400E', textTransform: 'none' }}>
+                  Cambiar dirección
+                </Button>
+              </Box>
+            ) : (
+              <>
+                <TextField fullWidth size="small" label="Depto / N° de estacionamiento (opcional)"
+                  value={state.depto} onChange={e => update({ depto: e.target.value })} sx={{ mb: 2 }} />
+                <TextField
+                  fullWidth size="small" required label="Email para comprobante" type="email"
+                  value={state.emailPago}
+                  onChange={e => update({ emailPago: e.target.value, customerSaved: false })}
+                  onBlur={async (e) => {
+                    const email = e.target.value.trim().toLowerCase()
+                    if (!email || !/\S+@\S+\.\S+/.test(email)) return
+                    update({ customerSaving: true, customerSaved: false })
+                    try {
+                      const res = await fetch('/api/customer', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                          email,
+                          address: state.address || '',
+                          city: state.addressCity || '',
+                          state: state.addressState || '',
+                          zipCode: state.addressZipCode || '',
+                          lat: state.addressLat || '',
+                          lng: state.addressLng || '',
+                          depto: state.depto || '',
+                          typeOfResidence: 'appartment',
+                          formId: state.formId ?? null,
+                        }),
+                      })
+                      update({ customerSaving: false, customerSaved: res.ok })
+                    } catch {
+                      update({ customerSaving: false, customerSaved: false })
+                    }
+                  }}
+                  helperText={state.customerSaving ? 'Verificando datos…' : 'Requerido para proceder al pago'}
+                  sx={{ mb: 2.5 }}
+                />
+                {state.webpayError && (
+                  <Alert severity="error" sx={{ mb: 2, fontSize: '0.8rem' }}>
+                    {state.webpayError}.{' '}
+                    <Button size="small" onClick={initiatePayment}
+                      sx={{ textTransform: 'none', fontSize: '0.78rem', p: 0, color: 'inherit', textDecoration: 'underline' }}>
+                      Reintentar
+                    </Button>
+                  </Alert>
+                )}
+                <Button fullWidth variant="contained" onClick={submitWebpay}
+                  disabled={!state.webpayData || state.webpayLoading || !state.emailPago.trim() || !state.addressValidated || state.customerSaving || !state.customerSaved}
+                  sx={{
+                    bgcolor: PINK, color: '#fff',
+                    '&:hover': { bgcolor: PINK_DARK },
+                    '&:disabled': { bgcolor: '#e0e0e0', color: '#aaa' },
+                    fontWeight: 700, py: 1.5, fontSize: '0.95rem', boxShadow: 'none',
+                  }}
+                >
+                  {state.webpayLoading ? 'Generando orden…' : 'Pagar $29.000 con Webpay →'}
+                </Button>
+                <Typography sx={{ fontSize: '0.7rem', color: TEXT_MUTED, textAlign: 'center', mt: 1 }}>
+                  Pago seguro · Visa, Mastercard, Redcompra, débito
+                </Typography>
+              </>
+            )}
+          </Box>
+        )}
+
         <Box sx={{ textAlign: 'center' }}>
           <Button
             variant="text"
@@ -1419,10 +1545,7 @@ export default function CotizadorWizard() {
   }
 
   function renderStep2() {
-    // Flujo B: edificio shows option selector unless dedicated was chosen
-    if (state.tipo === 'edificio' && state.edificioOption !== 'dedicated') {
-      return renderStep2Edificio()
-    }
+    if (state.tipo === 'edificio') return renderStep2Edificio()
 
     const localResult = result
     const displayResult = state.apiResult ?? localResult

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -406,8 +406,11 @@ export default function CotizadorWizard() {
   // ─── Derived ─────────────────────────────────────────────────────────────
   const canNext = (() => {
     if (state.step === 0) return state.tipo !== null
-    if (state.step === 1 && !state.showEdificioData) return state.tipoC !== null
-    if (state.showEdificioData) return state.edificioFloor.trim() !== '' && state.edificioParkingFloor !== ''
+    if (state.step === 1) {
+      if (!state.tipoC) return false
+      if (state.tipo === 'edificio') return state.edificioFloor.trim() !== '' && state.edificioParkingFloor !== ''
+      return true
+    }
     return true
   })()
 
@@ -415,16 +418,12 @@ export default function CotizadorWizard() {
     ? '¡Visita agendada!'
     : state.paid
     ? STEP_TITLES[state.step] ?? '¡Todo confirmado!'
-    : state.showEdificioData
-    ? 'Tu edificio'
     : STEP_TITLES[state.step] ?? 'Cotiza tu instalación'
 
   const heroSubtitle = state.booked
     ? 'Te contactaremos para confirmar los detalles'
     : state.paid
     ? STEP_SUBTITLES[state.step] ?? ''
-    : state.showEdificioData
-    ? 'Datos de tu edificio para calcular el costo de instalación'
     : STEP_SUBTITLES[state.step] ?? ''
 
   // ─── Handlers ────────────────────────────────────────────────────────────
@@ -433,16 +432,9 @@ export default function CotizadorWizard() {
   }
 
   async function goNext() {
-    // Edificio: intercept step 1 → show edificio data form first
-    if (state.step === 1 && state.tipo === 'edificio' && !state.showEdificioData) {
-      update({ showEdificioData: true })
-      return
-    }
-
-    // Trigger cotizar: from step 1 (casa) OR after completing edificio data form
-    const shouldCotizar = (state.step === 1 && state.tipo === 'casa') || state.showEdificioData
-    if (shouldCotizar) {
-      update({ showEdificioData: false, estimateLoading: true })
+    // Trigger cotizar API from step 1 (both casa and edificio)
+    if (state.step === 1) {
+      update({ estimateLoading: true })
       try {
         const isWallbox = state.tipoC === 'wallbox'
         const isPortable = state.tipoC === 'portable'
@@ -511,10 +503,6 @@ export default function CotizadorWizard() {
   }
 
   function goBack() {
-    if (state.showEdificioData) {
-      update({ showEdificioData: false })
-      return
-    }
     if (state.step > 0) {
       update({ step: state.step - 1, activePanel: null })
     }
@@ -988,6 +976,123 @@ export default function CotizadorWizard() {
             <Chip label={`${state.dist} m`} size="small" sx={{ bgcolor: 'rgba(232,26,104,0.08)', color: PINK, fontWeight: 700 }} />
           </Box>
         </Box>
+
+        {/* Edificio extra fields — only shown when tipo === 'edificio' */}
+        {state.tipo === 'edificio' && (
+          <Box sx={{ mt: 3, pt: 3, borderTop: `1px solid ${BORDER}` }}>
+            <Typography sx={{ fontWeight: 700, fontSize: '0.95rem', mb: 0.5, color: '#2A3547' }}>
+              Cuéntanos de tu edificio
+            </Typography>
+            <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED, mb: 2.5, lineHeight: 1.6 }}>
+              El costo depende del recorrido del cable desde el tablero común hasta tu estacionamiento.
+            </Typography>
+
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 1, color: '#2A3547' }}>
+              ¿En qué piso vives?
+            </Typography>
+            <TextField
+              fullWidth
+              size="small"
+              type="number"
+              placeholder="5"
+              inputProps={{ min: -10, max: 60 }}
+              value={state.edificioFloor}
+              onChange={e => update({ edificioFloor: e.target.value })}
+              sx={{
+                mb: 2.5,
+                '& .MuiOutlinedInput-root': {
+                  bgcolor: '#fff',
+                  '& fieldset': { borderColor: BORDER },
+                  '&:hover fieldset': { borderColor: TEAL },
+                  '&.Mui-focused fieldset': { borderColor: TEAL },
+                },
+              }}
+            />
+
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 1, color: '#2A3547' }}>
+              ¿En qué piso está tu estacionamiento?
+            </Typography>
+            <FormControl fullWidth size="small" sx={{ mb: 2.5 }}>
+              <Select
+                displayEmpty
+                value={state.edificioParkingFloor}
+                onChange={(e: SelectChangeEvent<string>) => update({ edificioParkingFloor: e.target.value as string })}
+                renderValue={(val: string) =>
+                  val
+                    ? val
+                    : <Typography sx={{ color: TEXT_MUTED, fontSize: '0.875rem' }}>Selecciona un piso…</Typography>
+                }
+                sx={{
+                  bgcolor: '#fff',
+                  '& .MuiOutlinedInput-notchedOutline': { borderColor: BORDER },
+                  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: TEAL },
+                  '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: TEAL },
+                  fontSize: '0.875rem',
+                }}
+              >
+                <MenuItem value="" disabled>
+                  <Typography sx={{ color: TEXT_MUTED, fontSize: '0.875rem' }}>Selecciona un piso…</Typography>
+                </MenuItem>
+                {PARKING_FLOORS.map(f => (
+                  <MenuItem key={f} value={f} sx={{ fontSize: '0.875rem' }}>{f}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <Typography sx={{ fontWeight: 600, fontSize: '0.85rem', mb: 0.5, color: '#2A3547' }}>
+              ¿Tu edificio tiene estacionamiento de visitas?
+            </Typography>
+            <Typography sx={{ fontSize: '0.78rem', color: TEXT_MUTED, mb: 1.5 }}>
+              Es donde podríamos instalar la electrolinera compartida.
+            </Typography>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 6 }}>
+                <Box
+                  onClick={() => update({ edificioVisitorParking: true })}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={e => e.key === 'Enter' && update({ edificioVisitorParking: true })}
+                  sx={{
+                    border: `2px solid ${state.edificioVisitorParking === true ? PINK : BORDER}`,
+                    borderRadius: 2,
+                    p: 2,
+                    cursor: 'pointer',
+                    bgcolor: state.edificioVisitorParking === true ? 'rgba(232,26,104,0.04)' : '#fff',
+                    textAlign: 'center',
+                    transition: 'all 0.2s',
+                    '&:hover': { borderColor: PINK, bgcolor: 'rgba(232,26,104,0.04)' },
+                  }}
+                >
+                  <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: state.edificioVisitorParking === true ? PINK : '#2A3547' }}>
+                    Sí
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid size={{ xs: 6 }}>
+                <Box
+                  onClick={() => update({ edificioVisitorParking: false })}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={e => e.key === 'Enter' && update({ edificioVisitorParking: false })}
+                  sx={{
+                    border: `2px solid ${state.edificioVisitorParking === false ? PINK : BORDER}`,
+                    borderRadius: 2,
+                    p: 2,
+                    cursor: 'pointer',
+                    bgcolor: state.edificioVisitorParking === false ? 'rgba(232,26,104,0.04)' : '#fff',
+                    textAlign: 'center',
+                    transition: 'all 0.2s',
+                    '&:hover': { borderColor: PINK, bgcolor: 'rgba(232,26,104,0.04)' },
+                  }}
+                >
+                  <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: state.edificioVisitorParking === false ? PINK : '#2A3547' }}>
+                    No
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+          </Box>
+        )}
       </Box>
     )
   }
@@ -2113,9 +2218,8 @@ export default function CotizadorWizard() {
               p: { xs: 3, md: 4 },
             }}
           >
-            {state.step === 0 && !state.showEdificioData && renderStep0()}
-            {state.step === 1 && !state.showEdificioData && renderStep1()}
-            {state.showEdificioData && renderEdificioData()}
+            {state.step === 0 && renderStep0()}
+            {state.step === 1 && renderStep1()}
             {state.step === 2 && renderStep2()}
             {state.step === 3 && renderStep3()}
             {state.step === 4 && renderStep4()}

--- a/src/app/postulacion-cargadores-edificios/PostulacionClient.tsx
+++ b/src/app/postulacion-cargadores-edificios/PostulacionClient.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  TextField,
+  Alert,
+} from '@mui/material'
+import HpHeaderNew from '@/app/components/shared/header/HpHeaderNew'
+import emailjs, { init as initEmailjs } from 'emailjs-com'
+
+const PINK = '#e81a68'
+const PINK_DARK = '#c01556'
+const TEAL = '#0898b9'
+const TEAL_LIGHT = '#4dbfd9'
+const SURFACE = '#F8FAFC'
+const TEXT_MUTED = '#64748B'
+const BORDER = '#E2E8F0'
+const SUCCESS = '#00C47C'
+
+interface FormState {
+  nombre: string
+  email: string
+  telefono: string
+  submitting: boolean
+  submitted: boolean
+  error: string
+}
+
+const APPROVAL_STEPS = [
+  { num: 1, title: 'Te registras hoy', desc: 'Recibes tu kit por correo' },
+  { num: 2, title: 'Presentas a tu comunidad', desc: 'Con la carta y presentación que te damos' },
+  { num: 3, title: 'Aprobación del comité', desc: 'Te acompañamos en la gestión' },
+  { num: 4, title: 'Instalación', desc: 'Energica instala y financia' },
+]
+
+export default function PostulacionClient() {
+  const [form, setForm] = useState<FormState>({
+    nombre: '',
+    email: '',
+    telefono: '',
+    submitting: false,
+    submitted: false,
+    error: '',
+  })
+
+  function update(partial: Partial<FormState>) {
+    setForm(prev => ({ ...prev, ...partial }))
+  }
+
+  async function handleSubmit() {
+    if (!form.nombre.trim() || !form.email.trim() || !form.telefono.trim()) return
+    update({ submitting: true, error: '' })
+
+    try {
+      initEmailjs('UYcrSeCqLGW8xqT4S')
+      await emailjs.send('service_dbrrm6b', 'template_eysyecb', {
+        to_email: 'hola@energica.city',
+        name: form.nombre,
+        subject: `Nueva postulación electrolinera en edificio — ${form.nombre}`,
+        CONTENT_HTML: `
+          <p><strong>Nueva postulación: Electrolinera compartida en edificio</strong></p>
+          <table style="border-collapse:collapse;width:100%;">
+            <tr><td style="padding:8px;border:1px solid #e8e8e8;font-weight:600;">Nombre</td><td style="padding:8px;border:1px solid #e8e8e8;">${form.nombre}</td></tr>
+            <tr><td style="padding:8px;border:1px solid #e8e8e8;font-weight:600;">Email</td><td style="padding:8px;border:1px solid #e8e8e8;">${form.email}</td></tr>
+            <tr><td style="padding:8px;border:1px solid #e8e8e8;font-weight:600;">Teléfono</td><td style="padding:8px;border:1px solid #e8e8e8;">${form.telefono}</td></tr>
+          </table>
+        `,
+      })
+      update({ submitted: true, submitting: false })
+    } catch {
+      update({ submitting: false, error: 'No se pudo enviar. Intenta nuevamente.' })
+    }
+  }
+
+  const canSubmit = form.nombre.trim() !== '' && form.email.trim() !== '' && form.telefono.trim() !== '' && !form.submitting
+
+  return (
+    <Box>
+      <HpHeaderNew />
+
+      {/* Hero */}
+      <Box sx={{ background: `linear-gradient(180deg, ${TEAL_LIGHT} 10%, ${TEAL} 80%)`, pt: 0, pb: 0 }}>
+        <Container maxWidth="sm" sx={{ px: { xs: 2, sm: 3 }, py: { xs: 3, sm: 4 } }}>
+          <Typography
+            variant="h1"
+            sx={{
+              fontSize: { xs: '1.5rem', md: '1.875rem' },
+              fontWeight: 800,
+              color: '#000000',
+              textAlign: 'center',
+              mb: 1,
+              fontFamily: 'Plus Jakarta Sans, sans-serif',
+            }}
+          >
+            {form.submitted ? 'Ya estás en la lista 🎉' : 'Electrolinera compartida en tu edificio'}
+          </Typography>
+          <Typography sx={{ color: '#000000', textAlign: 'center', fontSize: '0.9rem', lineHeight: 1.5 }}>
+            {form.submitted
+              ? 'Te enviamos el kit por email para presentar en tu comunidad'
+              : 'Sin inversión. Energica instala y financia. Tú solo pagas lo que cargas.'}
+          </Typography>
+        </Container>
+      </Box>
+
+      {/* Content */}
+      <Box sx={{ bgcolor: SURFACE, minHeight: '60vh', pt: { xs: 2, md: 4 }, pb: 6 }}>
+        <Container maxWidth="sm" sx={{ px: { xs: 1, sm: 3 } }}>
+
+          {!form.submitted ? (
+            /* ── Form ── */
+            <Box sx={{ bgcolor: '#fff', borderRadius: 3, boxShadow: '0 2px 24px rgba(0,0,0,0.08)', p: { xs: 3, md: 4 } }}>
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 0.5, color: '#2A3547' }}>
+                Regístrate para recibir tu kit
+              </Typography>
+              <Typography sx={{ fontSize: '0.85rem', color: TEXT_MUTED, mb: 3, lineHeight: 1.6 }}>
+                Te enviamos todo lo que necesitas para presentar en la próxima reunión de tu comunidad.
+              </Typography>
+
+              <TextField
+                fullWidth
+                size="small"
+                label="Nombre"
+                value={form.nombre}
+                onChange={e => update({ nombre: e.target.value })}
+                sx={{
+                  mb: 2,
+                  '& .MuiOutlinedInput-root': {
+                    bgcolor: '#fff',
+                    '& fieldset': { borderColor: BORDER },
+                    '&:hover fieldset': { borderColor: TEAL },
+                    '&.Mui-focused fieldset': { borderColor: TEAL },
+                  },
+                }}
+              />
+              <TextField
+                fullWidth
+                size="small"
+                label="Email"
+                type="email"
+                value={form.email}
+                onChange={e => update({ email: e.target.value })}
+                sx={{
+                  mb: 2,
+                  '& .MuiOutlinedInput-root': {
+                    bgcolor: '#fff',
+                    '& fieldset': { borderColor: BORDER },
+                    '&:hover fieldset': { borderColor: TEAL },
+                    '&.Mui-focused fieldset': { borderColor: TEAL },
+                  },
+                }}
+              />
+              <TextField
+                fullWidth
+                size="small"
+                label="Teléfono"
+                type="tel"
+                value={form.telefono}
+                onChange={e => update({ telefono: e.target.value })}
+                sx={{
+                  mb: 3,
+                  '& .MuiOutlinedInput-root': {
+                    bgcolor: '#fff',
+                    '& fieldset': { borderColor: BORDER },
+                    '&:hover fieldset': { borderColor: TEAL },
+                    '&.Mui-focused fieldset': { borderColor: TEAL },
+                  },
+                }}
+              />
+
+              {form.error && (
+                <Alert severity="error" sx={{ mb: 2, fontSize: '0.82rem' }}>
+                  {form.error}
+                </Alert>
+              )}
+
+              <Button
+                fullWidth
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+                sx={{
+                  bgcolor: PINK,
+                  '&:hover': { bgcolor: PINK_DARK },
+                  '&:disabled': { bgcolor: '#e0e0e0', color: '#aaa' },
+                  fontWeight: 700,
+                  py: 1.5,
+                  fontSize: '1rem',
+                  boxShadow: 'none',
+                  borderRadius: 2,
+                }}
+              >
+                {form.submitting ? 'Enviando…' : 'Quiero electrolinera en mi edificio →'}
+              </Button>
+              <Typography sx={{ fontSize: '0.72rem', color: TEXT_MUTED, textAlign: 'center', mt: 1 }}>
+                Sin compromiso si la comunidad la rechaza.
+              </Typography>
+            </Box>
+          ) : (
+            /* ── Success state ── */
+            <Box>
+              {/* Process steps */}
+              <Box sx={{ bgcolor: '#fff', borderRadius: 3, boxShadow: '0 2px 24px rgba(0,0,0,0.08)', p: { xs: 3, md: 4 }, mb: 2 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: '1rem', color: '#2A3547', mb: 2.5 }}>
+                  Cómo se aprueba en tu edificio
+                </Typography>
+                {APPROVAL_STEPS.map((s, i) => (
+                  <Box key={s.num} sx={{ display: 'flex', gap: 2, mb: i < APPROVAL_STEPS.length - 1 ? 2.5 : 0, alignItems: 'flex-start' }}>
+                    <Box sx={{
+                      width: 32,
+                      height: 32,
+                      borderRadius: '50%',
+                      bgcolor: PINK,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                      mt: 0.1,
+                    }}>
+                      <Typography sx={{ color: '#fff', fontSize: '0.78rem', fontWeight: 700 }}>{s.num}</Typography>
+                    </Box>
+                    <Box>
+                      <Typography sx={{ fontWeight: 700, fontSize: '0.9rem', color: '#2A3547', lineHeight: 1.3 }}>
+                        {s.title}
+                      </Typography>
+                      <Typography sx={{ fontSize: '0.8rem', color: TEXT_MUTED, mt: 0.25 }}>
+                        {s.desc}
+                      </Typography>
+                    </Box>
+                  </Box>
+                ))}
+
+                {/* Social proof */}
+                <Box sx={{ mt: 3, pt: 2.5, borderTop: `1px solid ${BORDER}`, textAlign: 'center' }}>
+                  <Typography sx={{ fontSize: '0.82rem', color: TEXT_MUTED }}>
+                    Ya operamos en <Box component="span" sx={{ fontWeight: 700, color: '#2A3547' }}>14 edificios</Box> · <Box component="span" sx={{ fontWeight: 700, color: '#2A3547' }}>+100 usuarios</Box> cargando
+                  </Typography>
+                </Box>
+              </Box>
+
+              {/* WhatsApp CTA */}
+              <Box
+                component="a"
+                href={`https://wa.me/56967666652?text=${encodeURIComponent('Hola, acabo de postular mi edificio para la electrolinera compartida y tengo una consulta.')}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ display: 'block', textDecoration: 'none', mb: 2 }}
+              >
+                <Button
+                  fullWidth
+                  variant="contained"
+                  sx={{
+                    bgcolor: '#25D366',
+                    '&:hover': { bgcolor: '#1ebe5d' },
+                    fontWeight: 700,
+                    py: 1.5,
+                    fontSize: '0.95rem',
+                    color: '#fff',
+                    boxShadow: 'none',
+                    borderRadius: 2,
+                    display: 'flex',
+                    gap: 1,
+                  }}
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                    <circle cx="12" cy="12" r="12" fill="#25D366"/>
+                    <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z" fill="#fff"/>
+                  </svg>
+                  💬 Hablar con un asesor por WhatsApp
+                </Button>
+              </Box>
+
+              {/* Nueva cotización */}
+              <Box sx={{ textAlign: 'center' }}>
+                <Box
+                  component="a"
+                  href="/cotizador"
+                  sx={{
+                    fontSize: '0.85rem',
+                    color: TEXT_MUTED,
+                    textDecoration: 'underline',
+                    cursor: 'pointer',
+                    '&:hover': { color: '#2A3547' },
+                  }}
+                >
+                  ↺ Nueva cotización
+                </Box>
+              </Box>
+            </Box>
+          )}
+        </Container>
+      </Box>
+    </Box>
+  )
+}

--- a/src/app/postulacion-cargadores-edificios/page.tsx
+++ b/src/app/postulacion-cargadores-edificios/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next'
+import PostulacionClient from './PostulacionClient'
+
+export const metadata: Metadata = {
+  title: 'Postula tu edificio para electrolinera compartida',
+  description: 'Instala un cargador compartido en el estacionamiento de visitas de tu edificio sin costo. Energica financia e instala.',
+}
+
+export default function PostulacionEdificiosPage() {
+  return <PostulacionClient />
+}


### PR DESCRIPTION
## Resumen

Este PR introduce el **nuevo flujo bifurcado del cotizador** según tipo de propiedad seleccionado en el paso 1.

### Flujo A — Casa (sin cambios estructurales, mejoras en cotización)

- Paso 3 ahora muestra **3 opciones de reserva** debajo del precio:
  - **Reserva 70%** — 15% dcto en instalación, paga hoy el 70% del precio descontado (badge: MEJOR PRECIO)
  - **Reserva 30%** — 7% dcto en instalación, paga hoy el 30% del precio descontado (badge: 🔥 LA MÁS ELEGIDA)
  - **Solo visita técnica** — $10.000 acreditable a la instalación, sin compromiso
- Cada opción llama directamente a `/api/payment` y redirige a Webpay (sin panel intermedio)

### Flujo B — Edificio (nuevo)

- **Paso 2** (dentro del selector de cargador): campos adicionales integrados inline cuando se selecciona Edificio:
  - ¿En qué piso vives? (número)
  - ¿En qué piso está tu estacionamiento? (dropdown: Piso 1–3, Subterráneo -1 a -4)
  - ¿Tu edificio tiene estacionamiento de visitas? (Sí/No)
- **Paso 3** muestra estimación referencial con rango fijo **$2.350.000 – $4.110.000** y dos opciones:
  - **Instalación dedicada** — paga visita $29.000 → `/api/payment` → Webpay directo
  - **Electrolinera compartida** ($0 inversión, $330/kWh) → redirige a `/postulacion-cargadores-edificios`

### Nueva ruta `/postulacion-cargadores-edificios`

- Formulario: Nombre, email, teléfono
- Submit → EmailJS → estado de éxito con proceso de aprobación comunal (4 pasos), social proof, CTA WhatsApp

### Técnico

- Nueva función `payDirect(amount, glosa)` — llama `/api/payment` + auto-submit form a Webpay
- `renderBookingOptions()` — opciones de reserva con cálculos dinámicos
- `renderStep2Edificio()` — vista completa del paso 3 para edificio
- Mobile-first, siguiendo tokens de DESIGN.md

## Test plan

- [ ] Flujo A: seleccionar Casa → cotización con 3 opciones → click redirige a Webpay
- [ ] Flujo B: seleccionar Edificio → rellenar campos → cotización con 2 opciones
- [ ] Flujo B: "Pagar visita" → Webpay con $29.000
- [ ] Flujo B: "Quiero electrolinera" → `/postulacion-cargadores-edificios`
- [ ] Postulación: formulario → EmailJS → pantalla de éxito
- [ ] `npm run build` sin errores