### PR TITLE
feat(tracking): sistema de tracking de eventos del cotizador

### DIFF
--- a/docs/cotizador-calculo-flujo.md
+++ b/docs/cotizador-calculo-flujo.md
@@ -1,0 +1,170 @@
+# Flujo de Cálculo del Cotizador — Enérgica
+
+## Resumen ejecutivo
+
+El cotizador genera una cotización de instalación de cargadores eléctricos en dos etapas: una estimación instantánea en el navegador (para mostrar precios mientras el usuario navega) y un cálculo definitivo en el servidor (que es el precio final que se presenta y se guarda).
+
+---
+
+## Inputs del usuario
+
+El usuario responde tres preguntas en el wizard:
+
+| Paso | Campo | Valores posibles |
+|------|-------|-----------------|
+| 1 | Tipo de instalación | `casa` o `edificio` |
+| 1 | Distancia de cableado | 1 a 60 metros (slider) |
+| 1 | Cargador | Portable / Wallbox / Ya tengo uno |
+| 1 (edificio) | Piso del departamento | Número |
+| 1 (edificio) | Piso del estacionamiento | Nivel 0, subterráneo 1–4 |
+| 1 (edificio) | Estacionamiento de visitas | Sí / No |
+
+---
+
+## Arquitectura del cálculo
+
+```
+Usuario → Wizard (estimación instantánea)
+               ↓ al avanzar al paso 2
+          /api/cotizar
+               ↓
+          AppSync → Lambda ProcessEstimate
+               ↓
+          Precio definitivo + desglose
+```
+
+---
+
+## Etapa 1 — Estimación instantánea (frontend)
+
+Mientras el usuario ajusta la distancia y elige el cargador, el precio se actualiza en tiempo real usando esta fórmula:
+
+### Precios base por tipo
+
+| Concepto | Casa | Edificio |
+|----------|-----:|--------:|
+| Materiales | $156.000 | $215.000 |
+| Instalación | $182.000 | $258.000 |
+| Trámite SEC | $25.000 | $35.000 |
+
+### Factor de distancia
+
+| Distancia | Factor |
+|-----------|-------:|
+| 0–5 m | 0,85 |
+| 6–10 m | 1,00 |
+| 11–20 m | 1,18 |
+| 21–40 m | 1,35 |
+| > 40 m | 1,55 |
+
+### Fórmula
+
+```
+factor_total = factor_distancia
+materiales   = base_materiales × factor_total
+instalación  = base_instalación × factor_total
+SEC          = valor fijo (no varía con la distancia)
+cargador     = precio_cargador / 1,19  (precio neto sin IVA)
+
+neto  = materiales + instalación + SEC + cargador
+IVA   = neto × 0,19
+total = neto + IVA
+```
+
+> Esta estimación es solo para mostrar un precio orientativo mientras el usuario navega. El precio definitivo lo calcula el servidor.
+
+---
+
+## Etapa 2 — Cálculo definitivo (backend Lambda)
+
+Al presionar "Ver cotización", el sistema envía los datos al servidor. La Lambda `ProcessEstimate` ejecuta un cálculo más detallado:
+
+### Paso 1 — Materiales reales (recipe)
+
+Se consulta en base de datos una "receta de instalación" según tipo (casa/edificio) y potencia del cargador (7 kW, 3,5 kW o 2,2 kW). La receta desglosa:
+
+- Cableado fijo y variable (calculado según corriente y distancia)
+- Canalización y ductos
+- Tablero eléctrico y componentes
+- Selección de sección de cable según norma eléctrica (mín. 2,5 mm², valida caída de voltaje ≤ 6,16V)
+
+### Paso 2 — Mano de obra
+
+```
+días_trabajo = 1 si distancia < 15 m
+               2 si distancia ≥ 15 m
+
+costo_mano_obra = jornal_instalador × días_trabajo
+costo_vehículo  = $45.000 × días_trabajo
+mano_obra_total = MIN(costo_mano_obra, materiales × 30%) + costo_vehículo
+```
+
+### Paso 3 — Costos operacionales y margen
+
+| Ítem | Monto |
+|------|------:|
+| Marketing | $7.500 |
+| Administración | $11.391 |
+| Plataforma | $500 |
+| Trámite SEC | $35.000 |
+| **Margen Enérgica** | **30% sobre costo neto** |
+
+Para cotizaciones de BYD (zeero.energica.city), se agrega además un cargo de dealer del 9,78%.
+
+### Paso 4 — Total
+
+```
+costo_neto    = materiales + mano_obra + costos_operacionales
+con_margen    = costo_neto × 1,30
+IVA           = con_margen × 0,19
+total_final   = con_margen + IVA
+```
+
+---
+
+## Diferencia Casa vs. Edificio
+
+| Aspecto | Casa | Edificio |
+|---------|------|---------|
+| Precios base | Menores | 38% más altos |
+| Trámite SEC | $25.000 | $35.000 |
+| Complejidad | Instalación directa | Requiere tablero común, recorrido por estacionamiento |
+
+El sistema registra el piso del departamento y del estacionamiento para uso futuro en la cotización (actualmente es información informativa).
+
+---
+
+## Flujo paso a paso
+
+```
+1. Usuario elige CASA o EDIFICIO
+      ↓
+2. Usuario ajusta distancia y elige cargador
+   → Sistema muestra precio orientativo en tiempo real
+      ↓
+3. Usuario presiona "Ver cotización"
+   → Se guarda formulario en base de datos (ClientForm)
+   → Se llama a ProcessEstimate en el servidor
+   → Se reciben hasta 2 alternativas (7kW y 3,5kW para wallbox; 2,2kW para portable)
+      ↓
+4. Se muestra Step 3 con precio definitivo desglosado:
+   - Costo de instalación (neto y con IVA)
+   - Costo del cargador (si el cliente lo compra a Enérgica)
+   - Total final con IVA
+      ↓
+5. El cliente elige: Reservar / Pagar / Enviar por email
+```
+
+---
+
+## Notas técnicas
+
+- El cálculo del backend es siempre el precio final. El cálculo del frontend es solo una estimación de UX.
+- Si el servidor falla, el sistema muestra el precio estimado del frontend como fallback.
+- El cargador es un precio separado de la instalación. Si el cliente ya tiene cargador, ese ítem es $0.
+- El IVA (19%) se aplica sobre el precio neto de instalación + cargador.
+- Los precios están en pesos chilenos (CLP) y no incluyen descuentos ni promociones especiales.
+
+---
+
+*Documento generado el 2026-06-16. Refleja la lógica de cálculo vigente en esa fecha.*

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import amplifyOutputsProd from '../../../../amplify_outputs.json'
+import amplifyOutputsDev from '../../../../amplify_outputs_dev.json'
+
+export const runtime = 'nodejs'
+
+function getAppSyncConfig() {
+  const isProd = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'DEV'
+  const outputs = isProd ? amplifyOutputsProd : amplifyOutputsDev
+  const data = (outputs as any).data
+  return { url: data.url as string, apiKey: data.api_key as string }
+}
+
+const CREATE_COTIZADOR_EVENT = /* GraphQL */ `
+  mutation CreateCotizadorEvent($input: CreateCotizadorEventInput!) {
+    createCotizadorEvent(input: $input) { eventId }
+  }
+`
+
+function safeProps(raw: unknown): string | null {
+  if (raw == null) return null
+  try { return JSON.stringify(JSON.parse(JSON.stringify(raw))) }
+  catch { return null }
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() !== '' ? v.trim() : null
+}
+
+function intOrNull(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? Math.trunc(v) : null
+}
+
+async function sendEvent(input: Record<string, unknown>) {
+  const { url, apiKey } = getAppSyncConfig()
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify({ query: CREATE_COTIZADOR_EVENT, variables: { input } }),
+    cache: 'no-store',
+  })
+  if (!res.ok) throw new Error(`AppSync HTTP ${res.status}: ${await res.text()}`)
+  const json = await res.json()
+  if (json.errors?.length && !json.data) throw new Error(json.errors.map((e: any) => e.message).join('; '))
+}
+
+export async function POST(req: Request) {
+  let body: any
+  try {
+    body = await req.json()
+  } catch {
+    try { body = JSON.parse(await req.text()) } catch { body = null }
+  }
+
+  const event = str(body?.event)
+  if (!event) return NextResponse.json({}, { status: 202 })
+
+  const input: Record<string, unknown> = {
+    event,
+    sessionId: str(body?.sessionId) ?? 'unknown',
+    anonymousId: str(body?.anonymousId) ?? 'unknown',
+    customerId: str(body?.customerId),
+    formId: str(body?.formId),
+    props: safeProps(body?.props),
+    url: str(body?.url),
+    referrer: str(body?.referrer),
+    device: str(body?.device),
+    step: intOrNull(body?.step),
+    createdAt: str(body?.timestamp) ?? new Date().toISOString(),
+  }
+
+  // Fire-and-forget: respond 202 before AppSync call
+  void sendEvent(input).catch(err => console.error('[/api/track]', err.message))
+
+  return NextResponse.json({}, { status: 202 })
+}

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -56,6 +56,10 @@ export async function POST(req: Request) {
   if (!event) return NextResponse.json({}, { status: 202 })
 
   const input: Record<string, unknown> = {
+    eventId:
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`,
     event,
     sessionId: str(body?.sessionId) ?? 'unknown',
     anonymousId: str(body?.anonymousId) ?? 'unknown',

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -71,6 +71,7 @@ export async function POST(req: Request) {
     device: str(body?.device),
     step: intOrNull(body?.step),
     createdAt: str(body?.timestamp) ?? new Date().toISOString(),
+    sourceUrl: str(body?.sourceUrl) ?? 'ENERGICA',
   }
 
   // Fire-and-forget: respond 202 before AppSync call

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -1011,6 +1011,7 @@ export default function CotizadorWizard() {
       // Update ClientForm step to QUOTE_SENT
       updateFormStep(state.formId, '2')
 
+      if (state.emailSolo) setTrackerIdentity({ customerId: state.emailSolo.trim().toLowerCase() })
       track('email_sent')
       update({
         emailSent: true,

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -23,6 +23,7 @@ import Footer from '@/app/components/shared/footer'
 import HpHeaderNew from '@/app/components/shared/header/HpHeaderNew'
 import { sendEmail } from '@/store/Estimate/services'
 import emailjs, { init as initEmailjs } from 'emailjs-com'
+import { track, setTrackerIdentity } from '@/lib/tracker'
 
 // ─── Color tokens ────────────────────────────────────────────────────────────
 const PINK = '#e81a68'
@@ -444,6 +445,17 @@ export default function CotizadorWizard() {
       .catch(() => {/* keep static fallback */})
   }, [])
 
+  // Track step 0 on mount
+  useEffect(() => { track('step_1_loaded') }, [])
+
+  // Track step_3_abandoned when user leaves while on step 2 and hasn't paid
+  useEffect(() => {
+    if (state.step !== 2 || state.paid) return
+    const onUnload = () => track('step_3_abandoned', { step: 2 })
+    window.addEventListener('beforeunload', onUnload)
+    return () => window.removeEventListener('beforeunload', onUnload)
+  }, [state.step, state.paid])
+
   const result = calcResult(state, chargerList)
 
   // ─── Derived ─────────────────────────────────────────────────────────────
@@ -520,6 +532,8 @@ export default function CotizadorWizard() {
             const apiMat = Number(est.materialsCost ?? 0)
             const apiInst = Number(est.installationCost ?? 0)
             const installGross = Math.round((apiMat + apiInst + secTramite) * 1.19)
+            setTrackerIdentity({ formId })
+            track('step_3_loaded', { formId, total: totalNeto + totalIva })
             update({
               estimateLoading: false,
               step: 2,
@@ -548,11 +562,13 @@ export default function CotizadorWizard() {
       } catch (err) {
         console.error('[cotizador] fetch /api/cotizar failed, falling back to local calc:', err)
       }
+      track('step_3_loaded', { formId: state.formId, total: result?.total })
       update({ estimateLoading: false, step: 2 })
       return
     }
 
     if (state.step < 2) {
+      track('step_2_loaded')
       update({ step: state.step + 1 })
     }
   }
@@ -676,6 +692,10 @@ export default function CotizadorWizard() {
       console.log('[payDirect] sessionStorage.paymentData written:', sessionStorage.getItem('paymentData'))
       sessionStorage.removeItem('wizardContext')
 
+      track('webpay_initiated', {
+        total: amount,
+        selectedPaymentOption: selectedPaymentOption,
+      })
       const form = document.createElement('form')
       form.method = 'POST'
       form.action = data.url
@@ -991,6 +1011,7 @@ export default function CotizadorWizard() {
       // Update ClientForm step to QUOTE_SENT
       updateFormStep(state.formId, '2')
 
+      track('email_sent')
       update({
         emailSent: true,
         emailSending: false,
@@ -1072,7 +1093,7 @@ export default function CotizadorWizard() {
           <Grid size={{ xs: 6 }}>
             <SelectionCard
               selected={state.tipo === 'casa'}
-              onClick={() => update({ tipo: 'casa' })}
+              onClick={() => { track('tipo_selected', { tipo: 'casa' }); update({ tipo: 'casa' }) }}
               icon="🏠"
               title="Casa"
               subtitle="Estacionamiento propio"
@@ -1081,7 +1102,7 @@ export default function CotizadorWizard() {
           <Grid size={{ xs: 6 }}>
             <SelectionCard
               selected={state.tipo === 'edificio'}
-              onClick={() => update({ tipo: 'edificio' })}
+              onClick={() => { track('tipo_selected', { tipo: 'edificio' }); update({ tipo: 'edificio' }) }}
               icon="🏢"
               title="Edificio"
               subtitle="Estacionamiento propio"
@@ -1139,7 +1160,7 @@ export default function CotizadorWizard() {
                 key={c.id}
                 charger={c}
                 selected={state.chargerId === c.id}
-                onClick={() => update({ chargerId: c.id })}
+                onClick={() => { track('charger_selected', { chargerId: c.id }); update({ chargerId: c.id }) }}
               />
             ))}
             <Box
@@ -1173,7 +1194,7 @@ export default function CotizadorWizard() {
               <Select
                 displayEmpty
                 value={state.chargerId ?? ''}
-                onChange={(e: SelectChangeEvent<string>) => update({ chargerId: (e.target.value as string) || null })}
+                onChange={(e: SelectChangeEvent<string>) => { const id = (e.target.value as string) || null; if (id) track('charger_selected', { chargerId: id }); update({ chargerId: id }) }}
                 renderValue={(val: string) => {
                   if (!val) return <Typography sx={{ color: TEXT_MUTED, fontSize: '0.875rem' }}>Elige un wallbox...</Typography>
                   if (val === 'own') return 'Ya tengo mi cargador (solo instalación)'
@@ -1827,6 +1848,7 @@ export default function CotizadorWizard() {
                               Recibirás una respuesta de nuestros consultores lo antes posible.
                             </p>`,
                         })
+                        track('electrolinera_submitted')
                         update({ webpayLoading: false, electrolineraSubmitted: true })
                       } catch {
                         update({ webpayLoading: false, webpayError: 'No se pudo enviar. Intenta nuevamente.' })
@@ -2193,12 +2215,16 @@ export default function CotizadorWizard() {
                 fullWidth
                 variant="contained"
                 disabled={state.webpayLoading}
-                onClick={() => update({
+                onClick={() => {
+                const isOpening = !(state.activePanel === 'visitaPago' && state.selectedReserveOption === opt.key)
+                if (isOpening) track('cta_reservar_clicked')
+                update({
                   selectedReserveOption: opt.key,
-                  activePanel: state.activePanel === 'visitaPago' && state.selectedReserveOption === opt.key ? null : 'visitaPago',
+                  activePanel: isOpening ? 'visitaPago' : null,
                   reservePendingAmount: opt.balance,
                   reservePendingGlosa: opt.key === 'r70' ? `Saldo 30% · Instalación cargador eléctrico` : `Saldo 70% · Instalación cargador eléctrico`,
-                })}
+                })
+              }}
                 sx={{
                   bgcolor: state.activePanel === 'visitaPago' && state.selectedReserveOption === opt.key ? '#94A3B8' : PINK,
                   '&:hover': { bgcolor: state.activePanel === 'visitaPago' && state.selectedReserveOption === opt.key ? '#64748B' : PINK_DARK },
@@ -2768,7 +2794,7 @@ export default function CotizadorWizard() {
             fullWidth
             variant="outlined"
             startIcon={<IconMail size={16} />}
-            onClick={() => update({ activePanel: state.activePanel === 'email' ? null : 'email' })}
+            onClick={() => { if (state.activePanel !== 'email') track('cta_email_clicked'); update({ activePanel: state.activePanel === 'email' ? null : 'email' }) }}
             sx={{
               bgcolor: '#fff',
               borderColor: BORDER,

--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -63,7 +63,8 @@ const INSTALL_BASE = {
   edificio: { mat: 215000, inst: 258000, sec: 35000 },
 }
 
-const TIPO_FACTOR = { casa: 1.1, edificio: 1.15 }
+// COSTO-EXTRA-COTIZADOR: factor adicional por tipo de instalación (desactivado temporalmente)
+// const TIPO_FACTOR = { casa: 1.1, edificio: 1.15 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 function dFactor(d: number): number {
@@ -189,7 +190,8 @@ interface CalcResult {
 function calcResult(state: WizardState, chargers: typeof CHARGERS = CHARGERS): CalcResult | null {
   if (!state.tipo || !state.tipoC) return null
   const base = INSTALL_BASE[state.tipo]
-  const f = dFactor(state.dist) * TIPO_FACTOR[state.tipo]
+  // COSTO-EXTRA-COTIZADOR: antes se multiplicaba también por TIPO_FACTOR[state.tipo] (1.1 casa / 1.15 edificio)
+  const f = dFactor(state.dist)
   const mat = Math.round(base.mat * f)
   const inst = Math.round(base.inst * f)
   const sec = base.sec

--- a/src/app/cotizador/agenda/AgendaClient.tsx
+++ b/src/app/cotizador/agenda/AgendaClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import HpHeaderNew from '@/app/components/shared/header/HpHeaderNew'
 import type { CalendarSlot } from '@/app/api/schedules/route'
 import type { ActiveVisit } from '@/app/api/active-visit/route'
+import { track } from '@/lib/tracker'
 
 interface PaymentData {
   customerId?: string
@@ -636,7 +637,7 @@ function AgendaContent() {
                   ) : (
                     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mb: 3 }}>
                       {dates.map((d, i) => (
-                        <Box key={i} onClick={d.available ? () => setSelectedDate(i) : undefined} sx={{
+                        <Box key={i} onClick={d.available ? () => { track('date_selected', { date: d.dateKey }); setSelectedDate(i) } : undefined} sx={{
                           p: '10px 14px', borderRadius: 2,
                           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
                           border: `1.5px solid ${selectedDate === i ? '#e81a68' : d.available ? '#E2E8F0' : 'transparent'}`,
@@ -691,6 +692,7 @@ function AgendaContent() {
                       if (data.error) {
                         setBookingError(data.error)
                       } else {
+                        track('booking_confirmed', { date: slot.dateKey })
                         setBooked(true)
                       }
                     } catch {

--- a/src/app/cotizador/pago/PagoClient.tsx
+++ b/src/app/cotizador/pago/PagoClient.tsx
@@ -43,7 +43,8 @@ const INSTALL_BASE = {
   edificio: { mat: 215000, inst: 258000, sec: 35000 },
 }
 
-const TIPO_FACTOR = { casa: 1.1, edificio: 1.15 }
+// COSTO-EXTRA-COTIZADOR: factor adicional por tipo de instalación (desactivado temporalmente)
+// const TIPO_FACTOR = { casa: 1.1, edificio: 1.15 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 function dFactor(d: number): number {
@@ -179,7 +180,8 @@ interface CalcResult {
 function calcResult(state: WizardState): CalcResult | null {
   if (!state.tipo || !state.tipoC) return null
   const base = INSTALL_BASE[state.tipo]
-  const f = dFactor(state.dist) * TIPO_FACTOR[state.tipo]
+  // COSTO-EXTRA-COTIZADOR: antes se multiplicaba también por TIPO_FACTOR[state.tipo] (1.1 casa / 1.15 edificio)
+  const f = dFactor(state.dist)
   const mat = Math.round(base.mat * f)
   const inst = Math.round(base.inst * f)
   const sec = base.sec

--- a/src/app/cotizador/recibo-pago/ReciboPagoClient.tsx
+++ b/src/app/cotizador/recibo-pago/ReciboPagoClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import HpHeaderNew from '@/app/components/shared/header/HpHeaderNew'
 import Footer from '@/app/components/shared/footer'
 import type { CalendarSlot } from '@/app/api/schedules/route'
+import { track } from '@/lib/tracker'
 
 interface PaymentData {
   // Payment confirmation fields (from /return after Webpay)
@@ -102,6 +103,7 @@ export default function ReciboPagoClient() {
       console.log('[recibo-pago] paymentData from sessionStorage:', JSON.stringify(parsed))
       console.log('[recibo-pago] email:', parsed?.email, '| customerId:', parsed?.customerId, '| shoppingCartId:', parsed?.shoppingCartId)
       setPaymentData(parsed)
+      track('payment_confirmed', { total: parsed?.total != null ? Number(parsed.total) : undefined })
       // Update ClientForm step to PAID_PENDING_SCHEDULE on page load
       if (parsed?.formId) {
         fetch('/api/update-step', {

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -15,6 +15,7 @@ export interface TrackPayload {
   device: 'mobile' | 'desktop'
   step?: number | null
   timestamp: string
+  sourceUrl: string
 }
 
 // Un sessionId por carga de módulo (≈ por pestaña/recarga).
@@ -73,6 +74,7 @@ export function track(event: string, props: Record<string, unknown> = {}): void 
     device: getDevice(),
     step: typeof props.step === 'number' ? (props.step as number) : null,
     timestamp: new Date().toISOString(),
+    sourceUrl: 'ENERGICA',
   }
 
   const data = JSON.stringify(payload)

--- a/src/lib/tracker.ts
+++ b/src/lib/tracker.ts
@@ -1,0 +1,93 @@
+// Tracker del cotizador. Estado de sesión a nivel de módulo (no exportado).
+
+const ENDPOINT = '/api/track'
+const UID_KEY = 'ec_uid'
+
+export interface TrackPayload {
+  event: string
+  props: Record<string, unknown>
+  sessionId: string
+  anonymousId: string
+  customerId?: string | null
+  formId?: string | null
+  url: string
+  referrer: string
+  device: 'mobile' | 'desktop'
+  step?: number | null
+  timestamp: string
+}
+
+// Un sessionId por carga de módulo (≈ por pestaña/recarga).
+const sessionId =
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2)
+
+// anonymousId persistente en localStorage. Lazy-init.
+let cachedAnonymousId: string | null = null
+function getAnonymousId(): string {
+  if (cachedAnonymousId) return cachedAnonymousId
+  try {
+    const existing = localStorage.getItem(UID_KEY)
+    if (existing) {
+      cachedAnonymousId = existing
+    } else {
+      const id =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2)
+      localStorage.setItem(UID_KEY, id)
+      cachedAnonymousId = id
+    }
+  } catch {
+    cachedAnonymousId = sessionId
+  }
+  return cachedAnonymousId
+}
+
+function getDevice(): 'mobile' | 'desktop' {
+  return /Mobi/i.test(navigator.userAgent) ? 'mobile' : 'desktop'
+}
+
+let identity: { customerId?: string | null; formId?: string | null } = {}
+
+export function setTrackerIdentity(
+  next: { customerId?: string | null; formId?: string | null }
+): void {
+  identity = { ...identity, ...next }
+}
+
+export function track(event: string, props: Record<string, unknown> = {}): void {
+  if (typeof window === 'undefined') return
+  if (!event) return
+
+  const payload: TrackPayload = {
+    event,
+    props,
+    sessionId,
+    anonymousId: getAnonymousId(),
+    customerId: identity.customerId ?? null,
+    formId: identity.formId ?? null,
+    url: window.location.pathname,
+    referrer: document.referrer,
+    device: getDevice(),
+    step: typeof props.step === 'number' ? (props.step as number) : null,
+    timestamp: new Date().toISOString(),
+  }
+
+  const data = JSON.stringify(payload)
+
+  try {
+    if (navigator.sendBeacon) {
+      const blob = new Blob([data], { type: 'application/json' })
+      if (navigator.sendBeacon(ENDPOINT, blob)) return
+    }
+  } catch { /* fallback to fetch */ }
+
+  fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: data,
+    keepalive: true,
+  }).catch(() => { /* tracking never breaks UX */ })
+}


### PR DESCRIPTION
## Resumen

- `src/lib/tracker.ts` — módulo client-side con sessionId por pestaña, anonymousId persistente (localStorage `ec_uid`), sendBeacon + fetch keepalive fallback, SSR-safe
- `src/app/api/track/route.ts` — API route Node.js fire-and-forget: responde 202 antes de llamar AppSync `CreateCotizadorEvent`
- `CotizadorWizard.tsx` — instrumentado con 13 eventos: `step_1_loaded`, `step_2_loaded`, `step_3_loaded`, `tipo_selected`, `charger_selected`, `cta_reservar_clicked`, `cta_email_clicked`, `webpay_initiated`, `email_sent`, `electrolinera_submitted`, `step_3_abandoned`
- `ReciboPagoClient.tsx` — `payment_confirmed`
- `AgendaClient.tsx` — `date_selected`, `booking_confirmed`
- `sourceUrl: 'ENERGICA'` en todos los eventos para distinguir de BYD
- `setTrackerIdentity({ customerId: email })` al enviar cotización por email
- `COSTO-EXTRA-COTIZADOR` comentado en `CotizadorWizard.tsx` y `PagoClient.tsx`
- `docs/cotizador-calculo-flujo.md` — documentación del flujo de cálculo

## Backend requerido

Este PR requiere que el modelo `CotizadorEvent` esté deployado en AppSync (ya está en producción, Jobs #428–#430 SUCCEED).

## Test plan

- [ ] Abrir `/cotizador` y verificar llamadas a `/api/track` en Network tab
- [ ] Completar flujo hasta paso 3 — verificar `step_1_loaded`, `step_2_loaded`, `step_3_loaded` en DynamoDB
- [ ] Enviar cotización por email — verificar `email_sent` con `customerId` = email del usuario
- [ ] Verificar en backoffice `/cotizador-funnel` que aparecen los eventos

🤖 Generated with Claude Code