### PR TITLE
fix(cotizador): alinear precio SEC entre frontend y backend

### DIFF
--- a/src/app/cotizador/CotizadorWizard.tsx
+++ b/src/app/cotizador/CotizadorWizard.tsx
@@ -527,13 +527,14 @@ export default function CotizadorWizard() {
             const chargerPrice = charger ? Math.round(charger.precio / 1.19) : 0
             const chargerGrossPrice = charger ? charger.precio : 0
             const chargerName = state.chargerId === 'own' ? 'Ya tiene cargador' : (charger?.name ?? '')
-            const secTramite = isHouse ? INSTALL_BASE.casa.sec : INSTALL_BASE.edificio.sec
+            // SEC ya está incluido en installationCost del backend — usar SECCost solo para display en email
+            const secTramite = Number(est.SECCost ?? (isHouse ? INSTALL_BASE.casa.sec : INSTALL_BASE.edificio.sec))
             const installNeto = Number(est.netPrice ?? 0)
-            const totalNeto = installNeto + chargerPrice + secTramite
+            const totalNeto = installNeto + chargerPrice
             const totalIva = Math.round(totalNeto * 0.19)
             const apiMat = Number(est.materialsCost ?? 0)
             const apiInst = Number(est.installationCost ?? 0)
-            const installGross = Math.round((apiMat + apiInst + secTramite) * 1.19)
+            const installGross = Math.round((apiMat + apiInst) * 1.19)
             setTrackerIdentity({ formId })
             track('step_3_loaded', { formId, total: totalNeto + totalIva })
             update({


### PR DESCRIPTION
## Resumen

- **Problema:** El frontend sumaba `secTramite=$25.000` (para casa) encima del precio que el backend ya calculó incluyendo TE6=$35.000 dentro de `installationCost`. Esto causaba que el precio mostrado al cliente ($523.899) fuera $29.750 más alto que el precio guardado en base de datos ($494.149).

- **Fix:** En `CotizadorWizard.tsx > goNext()`, se elimina la adición de `secTramite` de los cálculos de precio. El `sec` del `apiResult` ahora toma el valor real del backend (`est.SECCost`) para display en el email.

## Cambio

```diff
- const secTramite = isHouse ? INSTALL_BASE.casa.sec : INSTALL_BASE.edificio.sec
+ // SEC ya está incluido en installationCost del backend
+ const secTramite = Number(est.SECCost ?? (isHouse ? INSTALL_BASE.casa.sec : INSTALL_BASE.edificio.sec))
  const installNeto = Number(est.netPrice ?? 0)
- const totalNeto = installNeto + chargerPrice + secTramite
+ const totalNeto = installNeto + chargerPrice
  ...
- const installGross = Math.round((apiMat + apiInst + secTramite) * 1.19)
+ const installGross = Math.round((apiMat + apiInst) * 1.19)
```

## Efecto en precios (ejemplo: Casa, portátil, 10m)

| | Antes | Después |
|---|---|---|
| Precio mostrado al cliente | $523.899 | $494.149 |
| Precio en base de datos (backend) | $494.149 | $494.149 |
| Diferencia | $29.750 | $0 |

## Test plan

- [ ] Abrir /cotizador, seleccionar CASA, portátil, 10m → precio debe mostrar ≈ $494.149
- [ ] Verificar que el precio coincide con el guardado en DynamoDB
- [ ] Probar con EDIFICIO y wallbox para verificar que no hay regresión
- [ ] Verificar que el email enviado muestra SEC como $35.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)