### PR TITLE
refactor: migra dayjs → date-fns (8 archivos)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "chance": "^1.1.11",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^3.2.0",
-        "dayjs": "^1.11.13",
         "emailjs-com": "^3.2.0",
         "embla-carousel": "^8.6.0",
         "embla-carousel-auto-scroll": "8.6.0",
@@ -29902,12 +29901,6 @@
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
     },
     "node_modules/debounce-promise": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "chance": "^1.1.11",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^3.2.0",
-    "dayjs": "^1.11.13",
     "emailjs-com": "^3.2.0",
     "embla-carousel": "^8.6.0",
     "embla-carousel-auto-scroll": "8.6.0",

--- a/src/app/components/BookingCalendar/index.tsx
+++ b/src/app/components/BookingCalendar/index.tsx
@@ -4,16 +4,10 @@
 import React, { useState, useEffect } from 'react';
 import { DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import { Box, Grid, Typography, Button, Paper, Divider } from '@mui/material';
-import { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
-import 'dayjs/locale/es'; // Importa el idioma español para dayjs
-import weekday from 'dayjs/plugin/weekday'; // Plugin para obtener el día de la semana
-import isBetween from 'dayjs/plugin/isBetween'; // Plugin para verificar si una fecha está entre otras
-
-// Extiende dayjs con los plugins ANTES de usar dayjs en tu componente
-dayjs.extend(weekday);
-dayjs.extend(isBetween);
-dayjs.locale('es'); // Establece el idioma globalmente para dayjs
+import { format, parseISO, startOfWeek, endOfWeek, addDays, isSameDay, isBefore, isWithinInterval } from 'date-fns';
+import { AdapterDateFns as AdapterDateFnsV2 } from '@mui/x-date-pickers/AdapterDateFnsV2';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import es from 'date-fns/locale/es';
 
 // Define un tipo para tus horas disponibles
 interface TimeSlot {
@@ -53,54 +47,54 @@ const mockAvailableTimes: { [key: string]: TimeSlot[] } = {
 
 export default function BookingCalendar() {
   // Este es el día que el usuario seleccionó en el calendario de la izquierda
-  const [calendarSelectedDay, setCalendarSelectedDay] = useState<Dayjs | null>(dayjs());
+  const [calendarSelectedDay, setCalendarSelectedDay] = useState<Date | null>(new Date());
 
   // Este es el día que define la semana que se muestra a la derecha
-  const [weekDisplayStartDay, setWeekDisplayStartDay] = useState<Dayjs>(dayjs().startOf('week'));
+  const [weekDisplayStartDay, setWeekDisplayStartDay] = useState<Date>(startOfWeek(new Date()));
 
-  const [weekDays, setWeekDays] = useState<Dayjs[]>([]);
+  const [weekDays, setWeekDays] = useState<Date[]>([]);
   const [weekAvailableTimes, setWeekAvailableTimes] = useState<{ [key: string]: TimeSlot[] }>({});
 
   useEffect(() => {
     if (!calendarSelectedDay) return;
 
     // La semana a mostrar a la derecha se basa en el día seleccionado
-    const startOfWeek = calendarSelectedDay.startOf('week');
-    setWeekDisplayStartDay(startOfWeek); // Actualiza el estado de la semana que se está mostrando
+    const start = startOfWeek(calendarSelectedDay);
+    setWeekDisplayStartDay(start); // Actualiza el estado de la semana que se está mostrando
 
-    const daysInWeek: Dayjs[] = [];
+    const daysInWeek: Date[] = [];
     for (let i = 0; i < 7; i++) {
-      daysInWeek.push(startOfWeek.add(i, 'day'));
+      daysInWeek.push(addDays(start, i));
     }
     setWeekDays(daysInWeek);
 
     const newWeekAvailableTimes: { [key: string]: TimeSlot[] } = {};
     daysInWeek.forEach(day => {
-      const formattedDate = day.format('YYYY-MM-DD');
+      const formattedDate = format(day, 'yyyy-MM-dd');
       newWeekAvailableTimes[formattedDate] = mockAvailableTimes[formattedDate] || [];
     });
     setWeekAvailableTimes(newWeekAvailableTimes);
 
   }, [calendarSelectedDay]); // Se recalcula la semana cuando cambia el día seleccionado en el calendario
 
-  const handleDateChange = (date: Dayjs | null) => {
+  const handleDateChange = (date: Date | null) => {
     // Cuando el usuario selecciona un día en el calendario, actualizamos calendarSelectedDay
     setCalendarSelectedDay(date);
   };
 
-  const handleTimeSlotClick = (date: Dayjs, timeSlot: TimeSlot) => {
+  const handleTimeSlotClick = (date: Date, timeSlot: TimeSlot) => {
     if (timeSlot.available) {
-      alert(`Has seleccionado la hora: ${timeSlot.time} el día ${date.format('dddd, DD [de] MMMM')}`);
+      alert(`Has seleccionado la hora: ${timeSlot.time} el día ${format(date, "EEEE, dd 'de' MMMM", { locale: es })}`);
       // Aquí puedes añadir la lógica para reservar la cita
     } else {
       alert(`La hora ${timeSlot.time} no está disponible.`);
     }
   };
 
-  const shouldDisableDate = (day: Dayjs) => {
-    const formattedDay = day.format('YYYY-MM-DD');
+  const shouldDisableDate = (day: Date) => {
+    const formattedDay = format(day, 'yyyy-MM-dd');
     // Deshabilitar días pasados
-    if (day.isBefore(dayjs(), 'day')) {
+    if (isBefore(day, new Date())) {
       return true;
     }
     // Deshabilitar días sin horas disponibles
@@ -108,6 +102,7 @@ export default function BookingCalendar() {
   };
 
   return (
+    <LocalizationProvider dateAdapter={AdapterDateFnsV2} adapterLocale={es}>
     <Box sx={{ p: 4 }}>
       <Typography variant="h5" gutterBottom>
         Selecciona un horario para la cita
@@ -123,10 +118,10 @@ export default function BookingCalendar() {
             <DateCalendar
               // Ahora el DateCalendar usa calendarSelectedDay, que es el día exacto clicado
               value={calendarSelectedDay}
-              onChange={handleDateChange}
+              onChange={(date) => handleDateChange(date as Date | null)}
               views={['month', 'day']}
               disablePast={false} // Permitir seleccionar días pasados en el calendario si se desea verlos
-              shouldDisableDate={shouldDisableDate} // Esta función seguirá deshabilitando días sin citas o pasados
+              shouldDisableDate={(day) => shouldDisableDate(day as Date)} // Esta función seguirá deshabilitando días sin citas o pasados
               sx={{
                 width: '100%',
                 '.MuiPickersDay-root': {
@@ -143,10 +138,10 @@ export default function BookingCalendar() {
               slots={{
                 // Usamos renderDay para estilizar los días que pertenecen a la semana visible a la derecha
                 day: (props) => {
-                  const day = dayjs(props.day);
-                  const startOfDisplayWeek = weekDisplayStartDay.startOf('week');
-                  const endOfDisplayWeek = weekDisplayStartDay.endOf('week');
-                  const isWithinSelectedWeek = day.isBetween(startOfDisplayWeek, endOfDisplayWeek, null, '[]');
+                  const dayDate = props.day as Date;
+                  const startOfDisplayWeek = startOfWeek(weekDisplayStartDay);
+                  const endOfDisplayWeek = endOfWeek(weekDisplayStartDay);
+                  const isWithinSelectedWeek = isWithinInterval(dayDate, { start: startOfDisplayWeek, end: endOfDisplayWeek });
 
                   return (
                     <PickersDay
@@ -170,11 +165,11 @@ export default function BookingCalendar() {
         <Box sx={{ gridColumn: { xs: '1 / -1', md: 'span 9' } }}>
           <Paper elevation={3} sx={{ p: 2, display: 'flex', overflowX: 'auto' }}>
             {weekDays.map((day) => {
-              const formattedDay = day.format('YYYY-MM-DD');
+              const formattedDay = format(day, 'yyyy-MM-dd');
               const timesForDay = weekAvailableTimes[formattedDay] || [];
-              const isToday = day.isSame(dayjs(), 'day');
+              const isToday = isSameDay(day, new Date());
               // Resaltar el día seleccionado en el calendario también en la vista de la semana
-              const isSelectedDayInWeekView = calendarSelectedDay?.isSame(day, 'day');
+              const isSelectedDayInWeekView = calendarSelectedDay ? isSameDay(calendarSelectedDay, day) : false;
 
 
               return (
@@ -200,10 +195,10 @@ export default function BookingCalendar() {
                       pb: 1,
                     }}
                   >
-                    {day.format('ddd').toUpperCase()}{' '}
+                    {format(day, 'EEE', { locale: es }).toUpperCase()}{' '}
                     <br />
                     <Typography variant="h6" component="span">
-                      {day.format('D')}
+                      {format(day, 'd')}
                     </Typography>
                   </Typography>
                   <Divider sx={{ mb: 2 }} />
@@ -214,7 +209,7 @@ export default function BookingCalendar() {
                           key={index}
                           variant={slot.available ? 'outlined' : 'text'}
                           // Deshabilita si la hora no está disponible o el día es pasado
-                          disabled={!slot.available || day.isBefore(dayjs(), 'day')}
+                          disabled={!slot.available || isBefore(day, new Date())}
                           onClick={() => handleTimeSlotClick(day, slot)}
                           sx={{
                             minWidth: 'auto',
@@ -244,5 +239,6 @@ export default function BookingCalendar() {
         </Box>
       </Box>
     </Box>
+    </LocalizationProvider>
   );
 }

--- a/src/app/components/calendar/index.tsx
+++ b/src/app/components/calendar/index.tsx
@@ -2,16 +2,12 @@
 
 // components/BookingCalendar.tsx
 import React, { useState, useEffect, useId, useMemo } from 'react';
-import { Dayjs } from 'dayjs';
-import dayjs from 'dayjs';
-import 'dayjs/locale/es'; // Importa el idioma español
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import updateLocale from 'dayjs/plugin/updateLocale';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import Link from "next/link";
-
+import { format, parseISO, startOfWeek, endOfWeek, addDays, addWeeks, subWeeks, isSameDay, isBefore, startOfDay, isSameWeek } from 'date-fns';
+import { formatChileTime, toChileLocalDate, utcDateStr } from '@/utils/chile-tz';
+import es from 'date-fns/locale/es';
 
 type props = {
     date: string;
@@ -20,41 +16,8 @@ type props = {
 
 import { Box, Grid, Typography, Button, Paper, IconButton } from '@mui/material';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { AdapterDateFns as AdapterDateFnsV2 } from '@mui/x-date-pickers/AdapterDateFnsV2';
 import { DateCalendar } from '@mui/x-date-pickers/DateCalendar';
-
-// Configura dayjs con los plugins necesarios
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.extend(updateLocale);
-dayjs.locale('es'); // Establece el idioma español
-dayjs.tz.setDefault('America/Santiago'); // Establece la zona horaria de Santiago
-
-// Configura la semana para que comience en lunes y personaliza el idioma español
-dayjs.updateLocale('es', {
-  weekStart: 1,
-  months: [
-    'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-    'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
-  ],
-  monthsShort: [
-    'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
-    'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'
-  ],
-  weekdays: [
-    'Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'
-  ],
-  weekdaysShort: ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'],
-  weekdaysMin: ['Do', 'Lu', 'Ma', 'Mi', 'Ju', 'Vi', 'Sa'],
-  longDateFormat: {
-    LT: 'HH:mm',
-    LTS: 'HH:mm:ss',
-    L: 'DD/MM/YYYY',
-    LL: 'D [de] MMMM [de] YYYY',
-    LLL: 'D [de] MMMM [de] YYYY HH:mm',
-    LLLL: 'dddd, D [de] MMMM [de] YYYY HH:mm'
-  }
-});
 
 import LoadingIcon from "@/app/components/shared/LoadingIcon";
 
@@ -101,9 +64,9 @@ interface InstallerWithCalendar {
 
 
 export const toChileTime = (props: props) => {
-    const { date, format = "HH:mm" } = props;
+    const { date, format: fmt = 'HH:mm' } = props;
     const dateUTC = new Date(date);
-    return dayjs(dateUTC).tz('America/Santiago').format(format);
+    return formatChileTime(dateUTC, fmt);
 };
 
 
@@ -111,8 +74,10 @@ const environment = process.env.NEXT_PUBLIC_ENVIRONMENT || 'DEV';
     
       
 export default function BookingCalendar() {
-  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs().tz('America/Santiago').startOf('week'));
-  const [weekDays, setWeekDays] = useState<Dayjs[]>([]);
+  const [selectedDate, setSelectedDate] = useState<Date>(() =>
+    startOfWeek(toChileLocalDate(new Date()), { weekStartsOn: 1 })
+  );
+  const [weekDays, setWeekDays] = useState<Date[]>([]);
   const [weekAvailableTimes, setWeekAvailableTimes] = useState<{ [key: string]: TimeSlot[] }>({});
   const [initialLoad, setInitialLoad] = useState(true);
   const [selectedInstaller, setSelectedInstaller] = useState<string>("");
@@ -131,11 +96,11 @@ export default function BookingCalendar() {
 
   // Memoizamos las fechas de inicio y fin de semana
   const weekDates = useMemo(() => {
-    const startOfWeek = selectedDate.startOf('week');
-    const endOfWeek = selectedDate.endOf('week');
+    const weekStart = startOfWeek(selectedDate, { weekStartsOn: 1 });
+    const weekEnd = endOfWeek(selectedDate, { weekStartsOn: 1 });
     return {
-      startDate: startOfWeek.utc().format('YYYY-MM-DD[T]00:00:00.000[Z]'),
-      endDate: endOfWeek.utc().format('YYYY-MM-DD[T]00:00:00.000[Z]')
+      startDate: `${utcDateStr(weekStart)}T00:00:00.000Z`,
+      endDate: `${utcDateStr(weekEnd)}T00:00:00.000Z`
     };
   }, [selectedDate]);
 
@@ -173,11 +138,11 @@ export default function BookingCalendar() {
         handleInstaller(firstInstaller.userId);
         trackEvent('seleccion_instalador', 'firstInstaller.userId', firstInstaller.userId);
         // Luego cambiar la fecha
-        const installerDate = dayjs(firstInstaller.startDate);
-        const weekStart = installerDate.startOf('week');
-        
+        const installerDate = parseISO(firstInstaller.startDate);
+        const weekStart = startOfWeek(installerDate, { weekStartsOn: 1 });
+
         // Solo cambiar la fecha si es diferente a la actual
-        if (!selectedDate.isSame(weekStart, 'week')) {
+        if (!isSameWeek(selectedDate, weekStart, { weekStartsOn: 1 })) {
           handleDateChange(installerDate);
         }
       }
@@ -187,20 +152,20 @@ export default function BookingCalendar() {
   // Efecto para actualizar la vista semanal
   useEffect(() => {
     // Calcular los 7 días de la semana a partir de selectedDate
-    const startOfWeek = selectedDate.startOf('week');
-    const daysInWeek: Dayjs[] = [];
+    const weekStart = startOfWeek(selectedDate, { weekStartsOn: 1 });
+    const daysInWeek: Date[] = [];
     for (let i = 0; i < 5; i++) {
-      daysInWeek.push(startOfWeek.add(i, 'day'));
+      daysInWeek.push(addDays(weekStart, i));
     }
     setWeekDays(daysInWeek);
 
     // Obtener las horas disponibles para cada día de la semana
     const newWeekAvailableTimes: { [key: string]: TimeSlot[] } = {};
-    
+
     daysInWeek.forEach(day => {
-      const formattedDate = day.format('YYYY-MM-DD');
+      const formattedDate = format(day, 'yyyy-MM-dd');
       const visitsForDay = (calendarVisits as unknown as CalendarVisitsResponse)?.data?.filter((visit: CalendarVisit) => {
-        const visitDate = dayjs(visit.startDate).format('YYYY-MM-DD');
+        const visitDate = format(parseISO(visit.startDate), 'yyyy-MM-dd');
         return visitDate === formattedDate;
       }) || [];
 
@@ -222,16 +187,16 @@ export default function BookingCalendar() {
     await dispatch(setInstaller(installerId));
   };
 
-  const handleDateChange = (date: Dayjs | null) => {
+  const handleDateChange = (date: Date | null) => {
     if (date) {
-      trackEvent('seleccion_fecha', 'AGENDA_EMA', date.format('YYYY-MM-DD'));
-      const newDate = date.tz('America/Santiago').locale('es').startOf('week');
+      trackEvent('seleccion_fecha', 'AGENDA_EMA', format(date, 'yyyy-MM-dd'));
+      const newDate = startOfWeek(toChileLocalDate(date), { weekStartsOn: 1 });
       setSelectedDate(newDate);
     }
   };
 
-  const handleTimeSlotClick = async (date: Dayjs, timeSlot: TimeSlot) => {
-    trackEvent('seleccion_fecha_hora', 'AGENDA_EMA', `${date.format('YYYY-MM-DD')}_${timeSlot.time}`);
+  const handleTimeSlotClick = async (date: Date, timeSlot: TimeSlot) => {
+    trackEvent('seleccion_fecha_hora', 'AGENDA_EMA', `${format(date, 'yyyy-MM-dd')}_${timeSlot.time}`);
     
     if (timeSlot.available) {
       Promise.all([
@@ -241,7 +206,7 @@ export default function BookingCalendar() {
         dispatch(setStep(1))
       ])
     } else {
-      trackEvent('no_disponible_fecha_hora_seleccionada', 'AGENDA_EMA', `${date.format('YYYY-MM-DD')}_${timeSlot.time}`);
+      trackEvent('no_disponible_fecha_hora_seleccionada', 'AGENDA_EMA', `${format(date, 'yyyy-MM-dd')}_${timeSlot.time}`);
       alert(`La hora ${timeSlot.time} no está disponible.`);
     }
   };
@@ -250,24 +215,24 @@ export default function BookingCalendar() {
     // Funciones para cambiar de mes
   const handlePrevMonth = () => {
       trackEvent('cambio_semana_calendario', 'AGENDA_EMA', 'previous_month');
-      setSelectedDate(prev => prev.subtract(1, 'week'));
+      setSelectedDate(prev => subWeeks(prev, 1));
     };
     const handleNextMonth = () => {
       trackEvent('cambio_semana_calendario', 'AGENDA_EMA', 'next_month');
-      setSelectedDate(prev => prev.add(1, 'week'));
+      setSelectedDate(prev => addWeeks(prev, 1));
     };
     
   // Calcula el primer y último día de la semana seleccionada
-  const startOfWeek = selectedDate.startOf('week');
-  const endOfWeek = selectedDate.endOf('week');
+  const weekStart = startOfWeek(selectedDate, { weekStartsOn: 1 });
+  const weekEnd = endOfWeek(selectedDate, { weekStartsOn: 1 });
 
   // Si el mes y año son iguales, muestra solo uno
-  let weekLabel = startOfWeek.format('MMMM YYYY');
-  if (
-    startOfWeek.format('MMMM YYYY') !== endOfWeek.format('MMMM YYYY')
-  ) {
+  const weekStartLabel = format(weekStart, 'MMMM yyyy', { locale: es });
+  const weekEndLabel = format(weekEnd, 'MMMM yyyy', { locale: es });
+  let weekLabel = weekStartLabel;
+  if (weekStartLabel !== weekEndLabel) {
     // Si el mes o año cambian, muestra ambos
-    weekLabel = `${startOfWeek.format('MMMM YYYY')} - ${endOfWeek.format('MMMM YYYY')}`;
+    weekLabel = `${weekStartLabel} - ${weekEndLabel}`;
   }
 
   const handleInstallerDateClick = (installer: InstallerWithCalendar) => {
@@ -275,7 +240,7 @@ export default function BookingCalendar() {
     
     trackEvent('seleccion_proxima_fecha_instalador', 'AGENDA_EMA', `${installer.userId}_${installer.startDate}`);
     
-    const day = dayjs(installer.startDate);
+    const day = parseISO(installer.startDate);
     const slot: TimeSlot = {
       time: toChileTime({ date: installer.startDate }),
       available: true,
@@ -309,14 +274,14 @@ export default function BookingCalendar() {
         {/* Calendario mensual */}
         <Box sx={{ width: { xs: '100%', md: '30%' }, height: { xs: 'auto', md: 'auto' }, display: { xs: 'none', md: 'block' } }}>
           <Paper elevation={3} sx={{ p: 2, pb:10,  height: { xs: 'auto', md: 'auto' } }}>
-            <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
+            <LocalizationProvider dateAdapter={AdapterDateFnsV2} adapterLocale={es}>
               <DateCalendar
                 value={selectedDate}
-                onChange={handleDateChange}
+                onChange={(date) => handleDateChange(date as Date | null)}
                 views={['month', 'day']}
                 disablePast={true}
                 shouldDisableDate={(date) => {
-                  return date.isSame(dayjs(), 'day');
+                  return isSameDay(date as Date, new Date());
                 }}
                 sx={{
                   width: '100%',
@@ -447,7 +412,7 @@ export default function BookingCalendar() {
                     }}
                     onClick={() => handleInstallerDateClick(installer)}
                   >
-                    Reserve aquí <b> <br/>{dayjs(installer?.startDate).format('D [de] MMMM')} - {toChileTime({date:installer?.startDate})}</b>
+                    Reserve aquí <b> <br/>{installer?.startDate ? format(parseISO(installer.startDate), "d 'de' MMMM", { locale: es }) : ''} - {toChileTime({date:installer?.startDate})}</b>
                   </Typography>
                 </Box>
               ))}
@@ -502,9 +467,9 @@ export default function BookingCalendar() {
                 <Box sx={{position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'flex-start', width: '100%', overflowX: 'auto', paddingLeft:2 }}>
               
                 {weekDays.map((day, i) => {
-                  const formattedDay = day.format('YYYY-MM-DD');
+                  const formattedDay = format(day, 'yyyy-MM-dd');
                   const timesForDay = weekAvailableTimes[formattedDay] || [];
-                  const isToday = day.isSame(dayjs(), 'day');
+                  const isToday = isSameDay(day, new Date());
 
                   return (
                     <Box 
@@ -529,10 +494,10 @@ export default function BookingCalendar() {
                           textTransform: 'capitalize',
                         }}
                       >
-                        {day.format('dddd').slice(0, 3).toUpperCase()}
+                        {format(day, 'EEEE', { locale: es }).slice(0, 3).toUpperCase()}
                         <br />
                         <Typography variant="h6" component="span">
-                          {day.format('D')}
+                          {format(day, 'd')}
                         </Typography>
                       </Typography>
                       <Box sx={{ 
@@ -561,7 +526,7 @@ export default function BookingCalendar() {
                             <Button
                               key={`${formattedDay}-${slot.time}-${index}`}
                               variant={slot.available ? 'outlined' : 'text'}
-                              disabled={!slot.available || day.isBefore(dayjs(), 'day')}
+                              disabled={!slot.available || isBefore(day, startOfDay(new Date()))}
                               onClick={() => handleTimeSlotClick(day, slot)}
                               sx={{
                                 minWidth: 'auto',

--- a/src/app/components/shared/CalendarSteps/FormStep01.tsx
+++ b/src/app/components/shared/CalendarSteps/FormStep01.tsx
@@ -14,15 +14,9 @@ import {
   FormControlLabel,
   Radio,
 } from "@mui/material";
-import dayjs from "dayjs";
-import "dayjs/locale/es"; // Importa el idioma español
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-
-// Configurar los plugins de dayjs
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.locale("es"); // Configurar el idioma español
+import { format, parseISO } from 'date-fns';
+import { formatChileTime } from '@/utils/chile-tz';
+import es from 'date-fns/locale/es';
 
 
 import { useFormik } from 'formik';
@@ -123,9 +117,9 @@ export const FormStep01 = (props:any) => {
   const { trackEvent } = useAnalytics();
 
   const toChileTime = (dateSchedule: any) => {
-    const { date, format = "HH:mm" } = dateSchedule;
+    const { date, format: fmt = 'HH:mm' } = dateSchedule;
     const dateUTC = new Date(date);
-    return dayjs(dateUTC).tz("America/Santiago").format(format);
+    return formatChileTime(dateUTC, fmt);
   };
   
   const formik = useFormik({
@@ -200,7 +194,7 @@ export const FormStep01 = (props:any) => {
         setTimeout(() => {
           const paymentData = {
             email: values?.email,
-            date: dayjs(selectedCalendar.startDate).format("D [de] MMMM"),
+            date: format(parseISO(selectedCalendar.startDate), "d 'de' MMMM", { locale: es }),
             hour: toChileTime({ date: selectedCalendar.startDate }),
             address:
               `${values?.address || ""}, ${customer?.city || ""}`.trim() || "",

--- a/src/app/components/shared/CalendarSteps/FormStep04.tsx
+++ b/src/app/components/shared/CalendarSteps/FormStep04.tsx
@@ -2,8 +2,9 @@
 
 // components/OrderConfirmation.tsx
 import React, { useEffect, useState } from "react";
-import dayjs from "dayjs";
-import "dayjs/locale/es"; // Importa el idioma español
+import { format, parseISO } from 'date-fns';
+import { formatChileTime } from '@/utils/chile-tz';
+import es from 'date-fns/locale/es';
 
 import LoadingIcon from "@/app/components/shared/LoadingIcon";
 import PageContainer from "@/app/components/container/PageContainer";
@@ -85,11 +86,9 @@ export default function FormResumeVirtual() {
   const PRODUCT_NAME = "Visita Técnica ";
 
   const toChileTime = (dateSchedule: any) => {
-    const { date, format = "HH:mm" } = dateSchedule;
+    const { date, format: fmt = 'HH:mm' } = dateSchedule;
     const dateUTC = new Date(date);
-    return dayjs(dateUTC)
-      .tz("America/Santiago")
-      .format(format);
+    return formatChileTime(dateUTC, fmt);
   };
 
   useEffect(() => {
@@ -254,9 +253,7 @@ export default function FormResumeVirtual() {
                             }}
                           >
                             {/* {calendarData?.startDate} */}
-                            {dayjs(calendarData?.startDate).format(
-                              "D [de] MMMM"
-                            )}
+                            {calendarData?.startDate ? format(parseISO(calendarData.startDate), "d 'de' MMMM", { locale: es }) : ''}
                           </Typography>
                         </Box>
                       </Box>

--- a/src/app/forms/postulacion-electrolineras/PostulacionClient.tsx
+++ b/src/app/forms/postulacion-electrolineras/PostulacionClient.tsx
@@ -2,16 +2,6 @@
 
 // components/OrderConfirmation.tsx
 import React, { useEffect, useState } from "react";
-import dayjs from "dayjs";
-import "dayjs/locale/es"; // Importa el idioma español
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-
-// Configurar los plugins de dayjs
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.locale("es"); // Configurar el idioma español
-
 import PageContainer from "@/app/components/container/PageContainer";
 
 

--- a/src/slices/StepWizard/components/Step02.tsx
+++ b/src/slices/StepWizard/components/Step02.tsx
@@ -46,15 +46,7 @@ import {
   Divider,
   Chip,
 } from "@mui/material";
-import dayjs from "dayjs";
-import "dayjs/locale/es"; // Importa el idioma español
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
-
-// Configurar los plugins de dayjs
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.locale("es"); // Configurar el idioma español
+import { formatChileTime } from '@/utils/chile-tz';
 
 
 import { useFormik } from 'formik';
@@ -160,9 +152,9 @@ export const Step02 = (props:any) => {
   const { trackEvent } = useAnalytics();
 
   const toChileTime = (dateSchedule: any) => {
-    const { date, format = "HH:mm" } = dateSchedule;
+    const { date, format: fmt = 'HH:mm' } = dateSchedule;
     const dateUTC = new Date(date);
-    return dayjs(dateUTC).tz("America/Santiago").format(format);
+    return formatChileTime(dateUTC, fmt);
   };
 
   const formik = useFormik({

--- a/src/store/CalendarVisits/services.ts
+++ b/src/store/CalendarVisits/services.ts
@@ -2,8 +2,8 @@ import { generateClient, SelectionSet } from "aws-amplify/api";
 import * as MAIN from "../../../amplify/data/main.schema";
 import { calendarVisitInput } from './type';
 import { GraphQLResult } from '@aws-amplify/api';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
+import { addDays } from 'date-fns';
+import { utcDateStr } from '@/utils/chile-tz';
 
 import { Amplify } from "aws-amplify";
 import outputs from "../../../amplify_outputs.json";
@@ -65,8 +65,9 @@ interface ScheduleOneInstallerResponse {
 export const fetchLastScheduleOneInstaller = async (userId: string) => {
   try {
     
-    const startDate = dayjs().utc().startOf('day').format('YYYY-MM-DD[T]00:00:00.000[Z]');
-    const endDate = dayjs().utc().add(60, 'days').endOf('day').format('YYYY-MM-DD[T]00:00:00.000[Z]');
+    const now = new Date();
+    const startDate = `${utcDateStr(now)}T00:00:00.000Z`;
+    const endDate = `${utcDateStr(addDays(now, 60))}T00:00:00.000Z`;
 
     
     const response = await client.graphql<ScheduleOneInstallerResponse>({
@@ -160,8 +161,9 @@ export const fetchCalendarVisitsByState = async (objFilter: calendarVisitInput) 
 
 export const fetchLastScheduleInstallers = async () => {
   try {
-    const startDate = dayjs().utc().startOf('day').format('YYYY-MM-DD[T]00:00:00.000[Z]');
-    const endDate = dayjs().utc().add(30, 'days').endOf('day').format('YYYY-MM-DD[T]00:00:00.000[Z]');
+    const now = new Date();
+    const startDate = `${utcDateStr(now)}T00:00:00.000Z`;
+    const endDate = `${utcDateStr(addDays(now, 30))}T00:00:00.000Z`;
 
     const response = await client.graphql<ListUsersResponse>({
       query: `

--- a/src/store/CalendarVisits/slice.ts
+++ b/src/store/CalendarVisits/slice.ts
@@ -5,7 +5,7 @@ import { fetchCalendarVisitsByState, fetchLastScheduleInstallers, fetchLastSched
 import { getShoppingCart } from '../ShoppingCart/slice';
 import { getWebpayStart } from '../Webpay/slice';
 // import { AnyARecord } from 'node:dns';
-import dayjs from 'dayjs';
+import { parseISO, differenceInMilliseconds } from 'date-fns';
 
 interface CalendarVisitsSliceState {
   currentStep: number,
@@ -69,11 +69,11 @@ export const getLastScheduleInstallers = createAsyncThunk(
         if (Array.isArray(scheduleData) && scheduleData.length > 0) {
           
           
-          const now = dayjs();
+          const now = new Date();
           const closestDate = scheduleData.reduce((closest: any, current: any) => {
-            const currentDate = dayjs(current.startDate);
-            const closestDate = dayjs(closest.startDate);
-            return currentDate.diff(now) < closestDate.diff(now) ? current : closest;
+            const currentDate = parseISO(current.startDate);
+            const closestDateObj = parseISO(closest.startDate);
+            return differenceInMilliseconds(currentDate, now) < differenceInMilliseconds(closestDateObj, now) ? current : closest;
           }, scheduleData[0]);
 
           return {
@@ -111,12 +111,12 @@ export const getScheduleInstaller = createAsyncThunk(
     try {
       const response = await fetchLastScheduleOneInstaller(userId);
       
-      const now = dayjs();
+      const now = new Date();
       const closestDate = response.reduce((closest: any, current: any) => {
-        const currentDate = dayjs(current.startDate);
-        const closestDate = dayjs(closest.startDate);
-        
-        return currentDate.diff(now) < closestDate.diff(now) ? current : closest;
+        const currentDate = parseISO(current.startDate);
+        const closestDateObj = parseISO(closest.startDate);
+
+        return differenceInMilliseconds(currentDate, now) < differenceInMilliseconds(closestDateObj, now) ? current : closest;
       }, response[0]);
       
       // console.log(">>> getScheduleInstaller - closest date >>", closestDate);

--- a/src/utils/chile-tz.ts
+++ b/src/utils/chile-tz.ts
@@ -1,0 +1,44 @@
+/**
+ * Timezone utilities for America/Santiago without depending on date-fns-tz.
+ * date-fns-tz v3 requires date-fns v3 (named submodule exports), but this project uses v2.
+ */
+
+/**
+ * Format a UTC Date as HH:mm in America/Santiago timezone (default).
+ * The pattern parameter is kept for API compatibility with the previous dayjs helper.
+ */
+export function formatChileTime(date: Date, pattern = 'HH:mm'): string {
+  if (pattern === 'HH:mm') {
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'America/Santiago',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(date);
+    const h = parts.find(p => p.type === 'hour')!.value;
+    const m = parts.find(p => p.type === 'minute')!.value;
+    return `${h}:${m}`;
+  }
+  // Fallback for other patterns — not used in this project
+  return new Intl.DateTimeFormat('es-CL', { timeZone: 'America/Santiago' }).format(date);
+}
+
+/**
+ * Return a plain Date whose year/month/day match the current date in Santiago.
+ * Useful for computing start-of-week in Chilean local time.
+ */
+export function toChileLocalDate(date: Date): Date {
+  // toLocaleString gives us the wall-clock time in Santiago as a parseable string
+  const str = date.toLocaleString('en-US', { timeZone: 'America/Santiago' });
+  return new Date(str);
+}
+
+/**
+ * Format a Date as a yyyy-MM-dd string using UTC date components.
+ */
+export function utcDateStr(date: Date): string {
+  const y = date.getUTCFullYear();
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return `${y}-${mo}-${d}`;
+}


### PR DESCRIPTION
## Summary

- Elimina `dayjs` (^1.11.13) de `package.json` — dependencia ya no es necesaria
- Migra los 8 archivos que usaban dayjs a `date-fns` (^2.30.0), ya instalado
- Crea `src/utils/chile-tz.ts` con helpers basados en `Intl.DateTimeFormat` para reemplazar `date-fns-tz` v3 (incompatible con date-fns v2 a nivel de ESM)
- Reemplaza `AdapterDayjs` → `AdapterDateFnsV2` en los calendarios MUI

## Archivos migrados

| Archivo | Cambio principal |
|---------|-----------------|
| `src/store/CalendarVisits/services.ts` | `formatInTimeZone(now, 'UTC', …)` → `utcDateStr(now)` |
| `src/store/CalendarVisits/slice.ts` | `dayjs().diff()` → `differenceInMilliseconds` |
| `src/app/components/shared/CalendarSteps/FormStep01.tsx` | `formatInTimeZone` → `formatChileTime` |
| `src/app/components/shared/CalendarSteps/FormStep04.tsx` | `formatInTimeZone` → `formatChileTime` |
| `src/slices/StepWizard/components/Step02.tsx` | `formatInTimeZone` → `formatChileTime` |
| `src/app/forms/postulacion-electrolineras/PostulacionClient.tsx` | dayjs imports eliminados (sólo estaban en comentarios) |
| `src/app/components/BookingCalendar/index.tsx` | `AdapterDayjs` → `AdapterDateFnsV2`, tipos MUI adaptados |
| `src/app/components/calendar/index.tsx` | `toZonedTime` + `formatInTimeZone` → helpers Intl, lunes preservado |

## Test plan

- [ ] `npm run build` pasa sin errores (verificado localmente antes de este PR)
- [ ] Flujo de agenda: selección de instalador → selección de fecha → formulario de datos
- [ ] Visualización correcta de hora en zona horaria de Santiago (America/Santiago)
- [ ] Semana empieza en lunes en el calendario de agenda
- [ ] Cálculo de rangos de fecha (30 y 60 días) en queries a DynamoDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)